### PR TITLE
Fix a few typos in docs

### DIFF
--- a/docs/autogeneration.rst
+++ b/docs/autogeneration.rst
@@ -4,8 +4,6 @@ Code autogeneration
 The xsuite library uses code autogeneration to specialize kernel code for the different contexts.
 Three contexts are presently available: ``cpu``, ``cuda``,  and ``opencl``.
 
-An example annotated source file can be found `here <https://github.com/xsuite/xfields/blob/master/xfields/src/linear_interpolators.h>`_.
-
 
 The developer writes a single C source code, providing additional information through the comment strings (annotations) described in the following.
 

--- a/docs/codes_lost_particles.rst
+++ b/docs/codes_lost_particles.rst
@@ -1,7 +1,7 @@
 ====================
 Lost particles state
 ====================
-Particles lost by the simulation are have Particles.state <= 0. Different states
+Particles lost by the simulation have Particles.state <= 0. Different states
 are used to identify different particle loss events.
 
 =====  ==================================================================

--- a/docs/collimation.rst
+++ b/docs/collimation.rst
@@ -35,7 +35,7 @@ Such interface can be used to create a link with other programs for the modeling
 of these effects,  e.g. GEANT, FLUKA, K2, GuineaPig.
 
 The interaction is defined as an object that provides a ``.interact(particles)``
-method, which sets to zero the ``state`` flag for the particles that are lost and
+method, which sets to zero or negative the ``state`` flag for the particles that are lost and
 returns a dictionary with the coordinates of the secondary particles that are
 emitted. The interaction process is embedded in one or multiple
 :class:`xtrack.BeamInteraction` beam elements that can be included in Xtrack line.

--- a/docs/newbeamelement.rst
+++ b/docs/newbeamelement.rst
@@ -29,7 +29,7 @@ Although our beam element is defined by the single parameter (theta), it is conv
     import xobjects as xo
     import xtrack as xt
 
-    class SRotation(BeamElement):
+    class SRotation(xt.BeamElement):
 
         _xofields={
             'cos_z': xo.Float64,

--- a/docs/numericalreproducibility.rst
+++ b/docs/numericalreproducibility.rst
@@ -5,7 +5,7 @@ Numerical reproducibility
 In general Xsuite does not not guarantee the numerical reproducibilty of the computation, in the sense that results obtained on different CPUs/GPUs or with different compilers will be different at the level of the machine precision.
 This is mostly due to the fact that the underlying python libraries, and in particular numpy and scipy are not numerically portable. Xsuite compiled code is observed to be numerically portable, if compiled with the same set of compilers. CPU and GPU contexts are expected to give results that differ at the level of the machine precision.
 
-We have identified a recipe that allows obtaining numerically reproducible results from Xsuite on CPU , which is reported in the following. Notably this requires compiling numpy and scipy in a special way, disabling vectorization optimizations and using unoptimized BLAS and LAPACK libraries (expect significant impact on numpy and scipy performance is significant).
+We have identified a recipe that allows obtaining numerically reproducible results from Xsuite on CPU , which is reported in the following. Notably this requires compiling numpy and scipy in a special way, disabling vectorization optimizations and using unoptimized BLAS and LAPACK libraries (expect significant impact on numpy and scipy performance).
 We underline that such a recipe is observed to yield numerically portable results in the analyzed cases of interest and on the CPUs that we had available but **is not guaranteed to do so in all possible cases**.
 We cannot commit on keeping such a recipe in the future, as this depends on characteristics of underlying libraries that we do not control.
 

--- a/docs/particlesmanip.rst
+++ b/docs/particlesmanip.rst
@@ -90,7 +90,7 @@ provided input `zeta`, `delta` (zero is assumed as default). For example:
 Generating particles distributions
 ==================================
 
-For several applications it is convenient to generated the transverse
+For several applications it is convenient to generate the transverse
 coordinates in the normalized phase space and then transform them to physical
 coordinates. Xpart provides functions to generate independently particles
 distributions in the three dimensions, which are then combined using the
@@ -101,7 +101,7 @@ Example: Pencil beam
 --------------------
 
 The following example shows how to generate a distribution often used for
-collimantion studies, which combines:
+collimation studies, which combines:
 
  - A Gaussian distribution in (x, px);
  - A `pencil` distribution in (y, py);

--- a/docs/singlepart.rst
+++ b/docs/singlepart.rst
@@ -64,7 +64,7 @@ A simple tracking simulation can be configured and executed with the following p
 Step-by-step description
 ========================
 
-In this sections we will discussed in some more detail the difference steps outlined in the example above.
+In this sections we will discuss in some more detail the different steps outlined in the example above.
 
 Getting the Xline machine model
 -------------------------------


### PR DESCRIPTION
Found a few typos/issues. Some things to note:

- in `docs/autogeneration.rst` perhaps the link could be updated instead of deleted, I could not find the original file myself
- please check my understanding in [`docs/collimation.rst`](https://github.com/xsuite/xsuite/compare/main...szymonlopaciuk:fix_typos?expand=1#diff-8f41cb45c06aed5b1df30129f0c3d216aa4e3b5b15d09a49f2123b742a604cdc), I think it should be updated, but maybe I'm misunderstanding