### PR TITLE
create GitHub actions for testing on GitHub provided runners

### DIFF
--- a/.github/workflows/cron_test_gh.yaml
+++ b/.github/workflows/cron_test_gh.yaml
@@ -1,0 +1,19 @@
+# This is a workflow that should run daily
+name: Daily test workflow
+
+# Controls when the action will run.
+on:
+  schedule:
+    - cron: '00 19 * * *'  # run at 19:00 UTC daily
+
+# This workflow calls the test_gh.yaml workflow passing the default
+# branches as inputs
+jobs:
+  run-tests-cron-gh:
+    uses: ./.github/workflows/test_gh.yaml
+    with:
+      xobjects_location: 'xsuite:main'
+      xdeps_location: 'xsuite:main'
+      xpart_location: 'xsuite:main'
+      xtrack_location: 'xsuite:main'
+      xfields_location: 'xsuite:main'

--- a/.github/workflows/manual_test_gh.yaml
+++ b/.github/workflows/manual_test_gh.yaml
@@ -1,0 +1,42 @@
+# This is a test workflow that is manually triggered
+name: Manual test workflow
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    # Specify branches using the refspec-like syntax: <user>:<branch>
+    inputs:
+      xobjects_location:
+        description: 'xobjects branch'
+        default: 'xsuite:main'
+        required: true
+      xdeps_location:
+        description: 'xdeps branch'
+        default: 'xsuite:main'
+        required: true
+      xpart_location:
+        description: 'xpart branch'
+        default: 'xsuite:main'
+        required: true
+      xtrack_location:
+        description: 'xtrack branch'
+        default: 'xsuite:main'
+        required: true
+      xfields_location:
+        description: 'xfields branch'
+        default: 'xsuite:main'
+        required: true
+
+# This workflow calls the test_gh.yaml workflow passing the specified
+# branches as inputs
+jobs:
+  run-tests-manual-gh:
+    uses: ./.github/workflows/test_gh.yaml
+    with:
+      xobjects_location: ${{ inputs.xobjects_location }}
+      xdeps_location: ${{ inputs.xdeps_location }}
+      xpart_location: ${{ inputs.xpart_location }}
+      xtrack_location: ${{ inputs.xtrack_location }}
+      xfields_location: ${{ inputs.xfields_location }}

--- a/.github/workflows/test_gh.yaml
+++ b/.github/workflows/test_gh.yaml
@@ -1,0 +1,79 @@
+# This is a test workflow the other (GitHub runner based) workflows rely on
+name: Test workflow
+
+# Controls when the action will run. This is a reusable workflow.
+on:
+  workflow_call:
+    # Inputs the workflow accepts.
+    inputs:
+      xobjects_location:
+        required: true
+        type: string
+      xdeps_location:
+        required: true
+        type: string
+      xpart_location:
+        required: true
+        type: string
+      xtrack_location:
+        required: true
+        type: string
+      xfields_location:
+        required: true
+        type: string
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# The jobs are all run in independent environments. Here we will run a separate job
+# for each of the test suites specified in the matrix below.
+jobs:
+  run-tests:
+    # The type of runner that the job will run on: this one is provided by GitHub
+    runs-on: ubuntu-latest
+    
+    # Run tests for all the xsuite packages in separate jobs in parallel
+    strategy:
+      fail-fast: false
+      matrix:
+        test-suite:
+        - xobjects
+        - xdeps
+        - xpart
+        - xtrack
+        - xfields
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y pocl-opencl-icd
+        pip install pytest pyopencl cython
+    - name: Check out xsuite repos & pip install
+      env:
+        xobjects_branch: ${{ inputs.xobjects_location }}
+        xdeps_branch: ${{ inputs.xdeps_location }}
+        xpart_branch: ${{ inputs.xpart_location }}
+        xtrack_branch: ${{ inputs.xtrack_location }}
+        xfields_branch: ${{ inputs.xfields_location }}
+      run: |
+        for project in xobjects xdeps xpart xtrack xfields; do
+          branch_varname="${project}_branch"
+          project_branch=${!branch_varname}  # get value of the variable [project]_branch
+          
+          IFS=':' read -r -a parts <<< $project_branch
+          user="${parts[0]}"
+          branch="${parts[1]}"
+          
+          echo git clone -b "$branch" --single-branch "https://github.com/${user}/${project}.git"
+          
+          cd $GITHUB_WORKSPACE
+          git clone -b "$branch" --single-branch "https://github.com/${user}/${project}.git"
+          pip install -e "${GITHUB_WORKSPACE}/${project}[tests]"
+        done
+    - name: Print versions
+      run: pip freeze
+    - name: Run tests (${{ matrix.test-suite }})
+      env:
+        XOBJECTS_TEST_CONTEXTS: ContextCpu
+      run: |
+        cd $GITHUB_WORKSPACE/${{ matrix.test-suite }}
+        pytest --color=yes -v tests


### PR DESCRIPTION
An automatic test should happen everyday at 19:00+00 (hopefully, as it seems that GitHub is quite relaxed about sticking to the schedule with delays between a few minutes to an hour...).

Tests can also be scheduled manually from the 'Actions' tab, where [collaborators with write permissions](https://github.com/orgs/community/discussions/26622) can schedule the workflows giving specific branches to test with.