### PR TITLE
test_gpu.yaml: ignore error when all containers stopped

### DIFF
--- a/.github/workflows/test_gpu.yaml
+++ b/.github/workflows/test_gpu.yaml
@@ -90,7 +90,7 @@ jobs:
     if: always()
     steps:
       - name: Stop any containers lagging behind
-        run: docker kill $(docker ps -q --filter ancestor=xsuite-test-runner)
+        run: docker kill $(docker ps -q --filter ancestor=xsuite-test-runner) || true
       - name: Remove the test image
         run: docker image rm xsuite-test-runner
       - name: Prune containers and images


### PR DESCRIPTION
Fix the error that happened here https://github.com/xsuite/xsuite/actions/runs/3255628878

This essentially ignores the result of `docker kill`: the command fails if there are no running test containers (`docker ps` returns nothing). This fix should be enough. If `kill` fails for another reason, then the following command will do too, so it's unlikely the fix discards something important.