### PR TITLE
run pip with --upgrade in Dockerfile to override old Ubuntu versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
 RUN python3 -m venv --system-site-packages /opt/xsuite
 ENV PATH="/opt/xsuite/bin:$PATH"
 WORKDIR /opt/xsuite
-RUN pip install cython pytest pyopencl gitpython \
+RUN pip install --upgrade cython pytest pyopencl gitpython \
     && for project in xobjects xdeps xpart xtrack xfields; do \
       branch_varname="${project}_branch" \
       && project_branch=${!branch_varname} \


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

In particular, currently the cupy image (based on Ubuntu) on which the testing Dockerfile is based on ships with a version of pyopencl that is quite old. This runs `pip install` with `--upgrade` to make sure we test against the most recent versions of python packages.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
