### PR TITLE
workflows: add a UUID to image id to avoid collisions in concurrent runs

### DIFF
--- a/.github/workflows/cron_test_gpu.yaml
+++ b/.github/workflows/cron_test_gpu.yaml
@@ -6,10 +6,11 @@ on:
   schedule:
     - cron: '00 19 * * *'  # run at 19:00 UTC daily
 
-# This workflow calls the test_gh.yaml workflow passing the default
-# branches as inputs
+# This workflow calls the test_gpu.yaml workflow passing the default
+# branches as inputs. The cron workflow will not run on forks.
 jobs:
-  run-tests-cron-gh:
+  run-tests-cron-gpu:
+    if: github.repository == 'xsuite/xsuite'
     uses: ./.github/workflows/test_gpu.yaml
     with:
       xobjects_location: 'xsuite:main'

--- a/.github/workflows/test_gpu.yaml
+++ b/.github/workflows/test_gpu.yaml
@@ -26,21 +26,26 @@ on:
 # The jobs are all run in independent environments. Here we will run a separate job
 # for each of the test suites specified in the matrix below.
 jobs:
-  # First, we build our test image based on the instructions on Gitlab
+  # First, we build our test image
   build-test-image:
     runs-on: ['self-hosted']
+    outputs:
+      image_id: ${{ steps.build-image.outputs.image_id }}
     steps:
-      - name: Checkout the repo
+      - id: checkout-repo
+        name: Checkout the repo
         uses: actions/checkout@v3
-      - name: Build the test image
+      - id: build-image
+        name: Build the test image
         env:
-          config_repo: ${{ secrets.XSUITE_TEST_CONFIGS_GIT }}
           xobjects_branch: ${{ inputs.xobjects_location }}
           xdeps_branch: ${{ inputs.xdeps_location }}
           xpart_branch: ${{ inputs.xpart_location }}
           xtrack_branch: ${{ inputs.xtrack_location }}
           xfields_branch: ${{ inputs.xfields_location }}
         run: |
+          IMAGE="xsuite-test-runner-$(cat /proc/sys/kernel/random/uuid)"
+          echo "image_id=$IMAGE" >> $GITHUB_OUTPUT
           docker build \
             --no-cache=true \
             --build-arg xobjects_branch=${xobjects_branch} \
@@ -48,26 +53,28 @@ jobs:
             --build-arg xpart_branch=${xpart_branch} \
             --build-arg xtrack_branch=${xtrack_branch} \
             --build-arg xfields_branch=${xfields_branch} \
-            -t xsuite-test-runner .
+            -t $IMAGE .
 
   # Print out some stuff about the test environment
   image-sanity-checks:
     runs-on: ['self-hosted']
     needs: build-test-image
+    env:
+      image_id: ${{ needs.build-test-image.outputs.image_id }}
     steps:
       - name: CUDA info
-        run: docker run --rm --gpus all xsuite-test-runner nvidia-smi
+        run: docker run --rm --gpus all ${image_id} nvidia-smi
       - name: OpenCL info
-        run: docker run --rm --gpus all xsuite-test-runner clinfo
+        run: docker run --rm --gpus all ${image_id} clinfo
       - name: Package paths
-        run: docker run --rm --gpus all xsuite-test-runner python3 /opt/xsuite/xtrack/examples/print_package_paths.py
+        run: docker run --rm --gpus all ${image_id} python3 /opt/xsuite/xtrack/examples/print_package_paths.py
       - name: List dependencies
-        run: docker run --rm --gpus all xsuite-test-runner pip freeze
+        run: docker run --rm --gpus all ${image_id} pip freeze
 
   # Run the tests for each repo in parallel in a test container
   run-tests:
     runs-on: ['self-hosted']
-    needs: image-sanity-checks
+    needs: [build-test-image, image-sanity-checks]
     strategy:
       fail-fast: false
       matrix:
@@ -80,21 +87,28 @@ jobs:
 
     steps:
     - name: Run pytest
+      env:
+        image_id: ${{ needs.build-test-image.outputs.image_id }}
+        test_contexts: 'ContextCpu;ContextCupy;ContextPyopencl'
       run: |
         docker run --rm --gpus all \
-          --env XOBJECTS_TEST_CONTEXTS='ContextCpu;ContextCupy;ContextPyopencl' xsuite-test-runner \
+          --env XOBJECTS_TEST_CONTEXTS="${test_contexts}" \
+          ${image_id} \
           pytest --color=yes -v /opt/xsuite/${{ matrix.test-suite }}/tests
 
   # Cleanup after the tests by removing the image and making sure there are
   # no unused images and stopped containers
   teardown:
     runs-on: ['self-hosted']
-    needs: run-tests
+    needs: [build-test-image, run-tests]
+    env:
+      image_id: ${{ needs.build-test-image.outputs.image_id }}
     if: always()
     steps:
-      - name: Stop any containers lagging behind
-        run: docker kill $(docker ps -q --filter ancestor=xsuite-test-runner) || true
-      - name: Remove the test image
-        run: docker image rm xsuite-test-runner
-      - name: Prune containers and images
-        run: docker system prune -f
+      - name: Stop the containers and remove the image
+        run: |
+          docker container stop \
+            $(docker ps -q --filter ancestor=${image_id}) || true
+          docker container rm --volumes \
+            $(docker ps -qa --filter ancestor=${image_id}) || true
+          docker image rm ${image_id}


### PR DESCRIPTION
## Description

Currently, when testing on the self-hosted runner, the name of the image is reused between runs. This means that in the unlikely event that two workflows are running simultaneously and the teardown action of one run is picked up after the image build, the teardown of the first workflow will destroy the image and containers of the second run, causing it to fail. To prevent this from happening, in this PR a uuid is appended at the end of the image name used throughout the run. A more gracious teardown is also introduced.

Additionally, we skip running the cron workflow on forks. In this way one should be able to enable actions in their own user profile (to be able to run the workflows on github's runners) without being spammed with "workflow failed" emails every day.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
