### PR TITLE
Work around the issue with pip install -e on GitHub Ubuntu runners

### DIFF
--- a/.github/workflows/test_gh.yaml
+++ b/.github/workflows/test_gh.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   run-tests:
     # The type of runner that the job will run on: this one is provided by GitHub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     # Run tests for all the xsuite packages in separate jobs in parallel
     strategy:


### PR DESCRIPTION
Pin the GitHub runners to `ubuntu-20.04`. Long term solutions should be explored at some point in the future.

This fixes an issue that arises due to the crossover of three different problems:

1. Ubuntu 22.04 will be used by default on 'ubuntu' runners on GitHub runners (https://github.com/actions/runner-images/issues/6399).

2. Ubuntu 22.04 ships with `setuptools` version 59.x.x, which has a bug that does not allow an `--editable` installation of packages in `--user` mode. The flag `--user` is presumed regardless, as the location with packages is not writable by normal users (see https://github.com/pypa/pip/issues/7953 and https://bugs.launchpad.net/ubuntu/+source/setuptools/+bug/1994016).

3. We need an `--editable` installation in order to run tests, as the `test_data` folder is loaded with respect to the package root, and not the test root (see for example: https://github.com/xsuite/xpart/blob/45d621ad060bc25d361835bde1ed985609a24c49/tests/test_single_rf_harmonic_matcher.py#L25)