### PR TITLE
add a command line script `xsuite-prebuild` to precompile trackers

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,6 +20,14 @@ The Xsuite packages can be installed using pip:
 
 This installation allows using Xsuite on CPU. To use Xsuite on GPU, with the cupy and/or pyopencl you need to install the corresponding packages, as described in the :ref:`dedicated section<gpuinst>`.
 
+After the installation, you can choose to precompile some often-used kernels, in
+order to reduce the waiting time spent on running the simulations later on. This
+can be accomplished simply by running the following command:
+
+.. code-block:: bash
+
+    xsuite-precompile
+
 
 Developer installation
 ======================

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, find_packages
 from pathlib import Path
 
 #######################################
@@ -33,13 +33,16 @@ setup(
         'xfields',
         'xpart',
         'xdeps'
-        ],
+    ],
     url='https://xsuite.readthedocs.io/',
     license='Apache 2.0',
     download_url="https://pypi.python.org/pypi/xsuite",
     project_urls={
-            "Bug Tracker": "https://github.com/xsuite/xsuite/issues",
-            "Documentation": 'https://xsuite.readthedocs.io/',
-            "Source Code": "https://github.com/xsuite/xsuite",
-        },
-    )
+        "Bug Tracker": "https://github.com/xsuite/xsuite/issues",
+        "Documentation": 'https://xsuite.readthedocs.io/',
+        "Source Code": "https://github.com/xsuite/xsuite",
+    },
+    entry_points={
+        'console_scripts': ['xsuite-prebuild=xsuite.cli:main'],
+    },
+)

--- a/xsuite/cli.py
+++ b/xsuite/cli.py
@@ -1,0 +1,10 @@
+# copyright ################################# #
+# This file is part of the Xobjects Package.  #
+# Copyright (c) CERN, 2022.                   #
+# ########################################### #
+from xtrack.prebuild_kernels import regenerate_kernels
+
+
+def main():
+    regenerate_kernels()
+    print('Successfully compiled kernels.')


### PR DESCRIPTION
## Description

Introduce a command that allows to trigger the behaviour introduced in https://github.com/xsuite/xtrack/pull/267 directly:

```bash
$ xsuite-prebuild
```

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
