### PR TITLE
Update dev_guide_xtbe_lost_part_codes.rst

### DIFF
--- a/docs/dev_guide_xtbe_lost_part_codes.rst
+++ b/docs/dev_guide_xtbe_lost_part_codes.rst
@@ -11,5 +11,8 @@ State  Information
 -2     Lost due to a longitudinal cut.
 -10    Lost all energy in synchrotron radiation.
 -11    Found outside interpolation grid.
--333   Lost in collimator.
+-333   Lost in Everest collimator.
+-334   Lost in FLUKA collimator.
+-335   Lost in Geant4 collimator.
+-399   Collimator error.
 =====  ==================================================================

--- a/docs/dev_guide_xtbe_lost_part_codes.rst
+++ b/docs/dev_guide_xtbe_lost_part_codes.rst
@@ -19,7 +19,7 @@ State C flag                      Information
 -334  XC_LOST_ON_EVEREST_CRYSTAL  Lost in Everest crystal.
 -335  XC_LOST_ON_FLUKA            Lost in FLUKA collimator.
 -336  XC_LOST_ON_GEANT4           Lost in Geant4 collimator.
--339  XC_LOST_ON_ABSORBER         Lost in black absorber.
+-340  XC_LOST_ON_ABSORBER         Lost in black absorber.
 -390  XC_ERR_INVALID_TRACK        Invalid tracking in collimator (e.g. backtracking, during twiss).
 -399  XC_ERR                      General collimator error.
 ===== ==========================  ====================================================================

--- a/docs/dev_guide_xtbe_lost_part_codes.rst
+++ b/docs/dev_guide_xtbe_lost_part_codes.rst
@@ -9,7 +9,7 @@ State C flag                      Information
 0     XT_LOST_ON_APERTURE         Lost on explicit aperture element (e.g. LimitRect, LimitEllip etc.).
 -1    XP_LOST_ON_GLOBAL_AP        Lost on global aperture limit set in the tracker.
 -2    XT_LOST_ON_LONG_CUT         Lost due to a longitudinal cut.
--10   XT_LOST_ALL_E_IN_SYNC       Lost all energy in synchrotron radiation.
+-10   XT_LOST_ALL_E_IN_SYNRAD     Lost all energy in synchrotron radiation.
 -11   XF_OUTSIDE_INTERPOL         Found outside interpolation grid.
 -12   XF_TOO_MANY_PHOTONS         Too many photons in beamstrahlung.
 -20   RNG_ERR_SEEDS_NOT_SET       Random generator seeds not set.

--- a/docs/dev_guide_xtbe_lost_part_codes.rst
+++ b/docs/dev_guide_xtbe_lost_part_codes.rst
@@ -3,16 +3,23 @@ Lost particles state codes
 Particles lost by the simulation have Particles.state <= 0. Different states
 are used to identify different particle loss events.
 
-=====  ==================================================================
-State  Information
-=====  ==================================================================
-0      Lost on explicit aperture element (e.g. LimitRect, LimitEllip etc.).
--1     Lost on global aperture limit set in the tracker.
--2     Lost due to a longitudinal cut.
--10    Lost all energy in synchrotron radiation.
--11    Found outside interpolation grid.
--333   Lost in Everest collimator.
--334   Lost in FLUKA collimator.
--335   Lost in Geant4 collimator.
--399   Collimator error.
-=====  ==================================================================
+===== ==========================  ====================================================================
+State C flag                      Information
+===== ==========================  ====================================================================
+0     XT_LOST_ON_APERTURE         Lost on explicit aperture element (e.g. LimitRect, LimitEllip etc.).
+-1    XP_LOST_ON_GLOBAL_AP        Lost on global aperture limit set in the tracker.
+-2    XT_LOST_ON_LONG_CUT         Lost due to a longitudinal cut.
+-10   XT_LOST_ALL_E_IN_SYNC       Lost all energy in synchrotron radiation.
+-11   XF_OUTSIDE_INTERPOL         Found outside interpolation grid.
+-12   XF_TOO_MANY_PHOTONS         Too many photons in beamstrahlung.
+-20   RNG_ERR_SEEDS_NOT_SET       Random generator seeds not set.
+-21   RNG_ERR_INVALID_TRACK       Invalid tracking inside random generator element.
+-22   RNG_ERR_RUTH_NOT_SET        Random Rutherford parameters not set.
+-333  XC_LOST_ON_EVEREST          Lost in Everest collimator.
+-334  XC_LOST_ON_EVEREST_CRYSTAL  Lost in Everest crystal.
+-335  XC_LOST_ON_FLUKA            Lost in FLUKA collimator.
+-336  XC_LOST_ON_GEANT4           Lost in Geant4 collimator.
+-339  XC_LOST_ON_ABSORBER         Lost in black absorber.
+-390  XC_ERR_INVALID_TRACK        Invalid tracking in collimator (e.g. backtracking, during twiss).
+-399  XC_ERR                      General collimator error.
+===== ==========================  ====================================================================


### PR DESCRIPTION
Lost state flags for different collimators, as the underlying code is very different it is useful to disentangle those.