### PR TITLE
fix broken bullets in some tables of contents

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ numpy
 scipy
 pandas
 lark
+sphinx_rtd_theme>=0.5.2
+sphinx==5.3.0


### PR DESCRIPTION
Due to an issue with the compatibility of sphinx-rtd-theme and docutils, there are problems with rendering some doc elements when using the most recently available versions.

This is a known bug (see the latest comments on https://github.com/readthedocs/sphinx_rtd_theme/issues/1115 and https://github.com/readthedocs/sphinx_rtd_theme/issues/1323).

This pins Sphinx and sphinx-rtd-theme to versions that work.

- [x] Tested on a separate instance of readthedocs.