### PR TITLE
Add testing of precompiled kernels to the GH based workflows

### DIFF
--- a/.github/workflows/cron_test_gh.yaml
+++ b/.github/workflows/cron_test_gh.yaml
@@ -18,3 +18,14 @@ jobs:
       xtrack_location: 'xsuite:main'
       xfields_location: 'xsuite:main'
       xmask_location: 'xsuite:main'
+  run-tests-cron-gh-precompiled:
+    uses: ./.github/workflows/test_gh.yaml
+    with:
+      xobjects_location: 'xsuite:main'
+      xdeps_location: 'xsuite:main'
+      xpart_location: 'xsuite:main'
+      xtrack_location: 'xsuite:main'
+      xfields_location: 'xsuite:main'
+      xmask_location: 'xsuite:main'
+      precompile_kernels: true
+      xobjects_test_contexts: "ContextCpu"

--- a/.github/workflows/manual_test_gh.yaml
+++ b/.github/workflows/manual_test_gh.yaml
@@ -32,6 +32,15 @@ on:
         description: 'xmask branch'
         default: 'xsuite:main'
         required: true
+      precompile_kernels:
+        description: 'precompile kernels?'
+        type: boolean
+        default: false
+        required: true
+      xobjects_test_contexts:
+        description: xobjects test contexts
+        default: "ContextCpu;ContextCpu:auto"
+        required: true
 
 # This workflow calls the test_gh.yaml workflow passing the specified
 # branches as inputs
@@ -45,3 +54,4 @@ jobs:
       xtrack_location: ${{ inputs.xtrack_location }}
       xfields_location: ${{ inputs.xfields_location }}
       xmask_location: ${{ inputs.xmask_location }}
+      precompile_kernels: ${{ inputs.precompile_kernels }}

--- a/.github/workflows/test_gh.yaml
+++ b/.github/workflows/test_gh.yaml
@@ -24,6 +24,14 @@ on:
       xmask_location:
         required: true
         type: string
+      precompile_kernels:
+        required: false
+        default: false
+        type: boolean
+      xobjects_test_contexts:
+        required: false
+        default: "ContextCpu;ContextCpu:auto"
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 # The jobs are all run in independent environments. Here we will run a separate job
@@ -90,11 +98,21 @@ jobs:
             "https://github.com/${user}/${project}.git"
           pip install -e "${GITHUB_WORKSPACE}/${project}[tests]"
         done
+    - name: Checkout xsuite (needed to precompile kernels)
+      if: ${{ inputs.precompile_kernels == true }}
+      uses: actions/checkout@v3
+      with:
+        path: 'xsuite'
+    - name: Precompile kernels
+      if: ${{ inputs.precompile_kernels == true }}
+      run: |
+        pip install -e "${GITHUB_WORKSPACE}/xsuite"
+        xsuite-prebuild
     - name: Print versions
       run: conda list
     - name: Run tests (${{ matrix.test-suite }})
       env:
-        XOBJECTS_TEST_CONTEXTS: "ContextCpu;ContextCpu:auto"
+        XOBJECTS_TEST_CONTEXTS: ${{ inputs.xobjects_test_contexts }}
       run: |
         cd $GITHUB_WORKSPACE/${{ matrix.test-suite }}
         python -m pytest --color=yes -v tests


### PR DESCRIPTION
## Description

This adds the following functionalities to the GitHub based workflows:

- Add a flag to prebuilt kernels
- Allow defining test contexts
- Add a cron job for precompiled kernels