### PR TITLE
Separate the GPU workflows into one for each context

### DIFF
--- a/.github/workflows/cron_test_gpu_cl.yaml
+++ b/.github/workflows/cron_test_gpu_cl.yaml
@@ -1,10 +1,10 @@
 # This is a workflow that should run daily
-name: Daily test (self-hosted, GPU)
+name: Daily test (self-hosted, OpenCL)
 
 # Controls when the action will run.
 on:
   schedule:
-    - cron: '00 19 * * *'  # run at 19:00 UTC daily
+    - cron: '00 01 * * *'  # run at 01:00 UTC daily
 
 # This workflow calls the test_gpu.yaml workflow passing the default
 # branches as inputs. The cron workflow will not run on forks.
@@ -20,4 +20,4 @@ jobs:
       xfields_location: 'xsuite:main'
       xmask_location: 'xsuite:main'
       xcoll_location: 'xsuite:main'
-      test_contexts: 'ContextCupy;ContextPyopencl'
+      test_contexts: 'ContextPyopencl'

--- a/.github/workflows/cron_test_gpu_cuda.yaml
+++ b/.github/workflows/cron_test_gpu_cuda.yaml
@@ -1,0 +1,23 @@
+# This is a workflow that should run daily
+name: Daily test (self-hosted, CUDA)
+
+# Controls when the action will run.
+on:
+  schedule:
+    - cron: '00 19 * * *'  # run at 19:00 UTC daily
+
+# This workflow calls the test_gpu.yaml workflow passing the default
+# branches as inputs. The cron workflow will not run on forks.
+jobs:
+  run-tests-cron-gpu:
+    if: github.repository == 'xsuite/xsuite'
+    uses: ./.github/workflows/test_gpu.yaml
+    with:
+      xobjects_location: 'xsuite:main'
+      xdeps_location: 'xsuite:main'
+      xpart_location: 'xsuite:main'
+      xtrack_location: 'xsuite:main'
+      xfields_location: 'xsuite:main'
+      xmask_location: 'xsuite:main'
+      xcoll_location: 'xsuite:main'
+      test_contexts: 'ContextCupy'


### PR DESCRIPTION
## Description

Due to strange memory problems most likely caused by PyOpenCL we separate the GPU test workflows into two separate ones: one for CUDA and one for OpenCL. Hopefully this will give a short term fix for the immediate PyOpenCL problem as well as will make it clearer which tests pass and which ones fail.