### PR TITLE
Add the second runner to paralelize CL and CUDA tests

### DIFF
--- a/.github/workflows/cron_test_gpu_cl.yaml
+++ b/.github/workflows/cron_test_gpu_cl.yaml
@@ -4,7 +4,7 @@ name: Daily test (self-hosted, OpenCL)
 # Controls when the action will run.
 on:
   schedule:
-    - cron: '00 01 * * *'  # run at 01:00 UTC daily
+    - cron: '00 19 * * *'  # run at 19:00 UTC daily
 
 # This workflow calls the test_gpu.yaml workflow passing the default
 # branches as inputs. The cron workflow will not run on forks.
@@ -21,3 +21,4 @@ jobs:
       xmask_location: 'xsuite:main'
       xcoll_location: 'xsuite:main'
       test_contexts: 'ContextPyopencl'
+      platform: 'alma'

--- a/.github/workflows/cron_test_gpu_cuda.yaml
+++ b/.github/workflows/cron_test_gpu_cuda.yaml
@@ -21,3 +21,4 @@ jobs:
       xmask_location: 'xsuite:main'
       xcoll_location: 'xsuite:main'
       test_contexts: 'ContextCupy'
+      platform: 'ubuntu'

--- a/.github/workflows/manual_test_gpu.yaml
+++ b/.github/workflows/manual_test_gpu.yaml
@@ -40,6 +40,10 @@ on:
         description: test contexts
         default: 'ContextCpu;ContextCpu:auto;ContextCupy;ContextPyopencl'
         required: false
+      platform:
+        description: platform
+        default: 'ubuntu'
+        required: true
 
 # This workflow calls the test_gpu.yaml workflow passing the specified
 # branches as inputs
@@ -56,3 +60,4 @@ jobs:
       xmask_location: ${{ inputs.xmask_location }}
       xcoll_location: ${{ inputs.xcoll_location }}
       test_contexts: ${{ inputs.test_contexts }}
+      platform: ${{ inputs.platform }}

--- a/.github/workflows/test_gpu.yaml
+++ b/.github/workflows/test_gpu.yaml
@@ -31,6 +31,9 @@ on:
         required: false
         type: string
         default: 'ContextCpu;ContextCpu:auto;ContextCupy;ContextPyopencl'
+      platform:
+        required: true
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 # The jobs are all run in independent environments. Here we will run a separate job
@@ -38,7 +41,7 @@ on:
 jobs:
   # First, we build our test image
   build-test-image:
-    runs-on: ['self-hosted']
+    runs-on: [self-hosted, "${{ inputs.platform }}"]
     outputs:
       image_id: ${{ steps.build-image.outputs.image_id }}
     steps:
@@ -72,7 +75,7 @@ jobs:
 
   # Print out some stuff about the test environment
   image-sanity-checks:
-    runs-on: ['self-hosted']
+    runs-on: [self-hosted, "${{ inputs.platform }}"]
     needs: build-test-image
     env:
       image_id: ${{ needs.build-test-image.outputs.image_id }}
@@ -88,7 +91,7 @@ jobs:
 
   # Run the tests for each repo in parallel in a test container
   run-tests:
-    runs-on: ['self-hosted']
+    runs-on: [self-hosted, "${{ inputs.platform }}"]
     needs: [build-test-image, image-sanity-checks]
     strategy:
       fail-fast: false
@@ -116,7 +119,7 @@ jobs:
   # Cleanup after the tests by removing the image and making sure there are
   # no unused images and stopped containers
   teardown:
-    runs-on: ['self-hosted']
+    runs-on: [self-hosted, "${{ inputs.platform }}"]
     needs: [build-test-image, run-tests]
     env:
       image_id: ${{ needs.build-test-image.outputs.image_id }}


### PR DESCRIPTION
## Description

This sets up the workflows to work with a second self-hosted runner, in such a way that the tests on the PyOpenCL contexts are ran at the same time as the ones for CUDA but on a different machine.