### PR TITLE
Run ocl tests separately

### DIFF
--- a/.github/workflows/test_gpu.yaml
+++ b/.github/workflows/test_gpu.yaml
@@ -114,7 +114,7 @@ jobs:
         mkdir -p reports/${{ matrix.test-suite }}
         docker run --rm --gpus all \
           --env XOBJECTS_TEST_CONTEXTS="${test_contexts}" \
-          -v $PWD/reports/${{ matrix.test-suite }}:/opt/reports \
+          -v $PWD/reports/${{ matrix.test-suite }}:/opt/reports:Z \
           ${image_id} \
           /opt/run_tests.sh /opt/xsuite/${{ matrix.test-suite }}/tests
     - name: Upload report

--- a/.github/workflows/test_gpu.yaml
+++ b/.github/workflows/test_gpu.yaml
@@ -111,10 +111,18 @@ jobs:
         image_id: ${{ needs.build-test-image.outputs.image_id }}
         test_contexts: ${{ inputs.test_contexts }}
       run: |
+        mkdir -p reports/${{ matrix.test-suite }}
         docker run --rm --gpus all \
           --env XOBJECTS_TEST_CONTEXTS="${test_contexts}" \
+          -v $PWD/reports/${{ matrix.test-suite }}:/opt/reports \
           ${image_id} \
-          pytest --color=yes -v /opt/xsuite/${{ matrix.test-suite }}/tests
+          /opt/run_tests.sh /opt/xsuite/${{ matrix.test-suite }}/tests
+    - name: Upload report
+      uses: actions/upload-artifact@v3
+      with:
+        name: report-${{ matrix.test-suite }}
+        path: reports/${{ matrix.test-suite }}/report.html
+        if-no-files-found: ignore
 
   # Cleanup after the tests by removing the image and making sure there are
   # no unused images and stopped containers

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,7 @@ RUN pip install --upgrade cython pytest pyopencl gitpython \
     done
 
 # Don't run tests from /opt/venv not to confuse imports
+COPY run_tests.sh /opt/
+RUN chmod +x /opt/run_tests.sh
 WORKDIR /opt
 CMD python3 /opt/xsuite/xtrack/examples/print_package_paths.py

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -15,8 +15,8 @@ REPORTS_DIR="/opt/reports"
 # Keep track of failures
 STATUS=0
 
-# If on Pyopencl context, run tests one by one, otherwise run normally
-if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextPyopencl" ]]; then
+# If xtrack on Pyopencl context, run tests one by one, otherwise run normally
+if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextPyopencl" ]] && [[ $* =~ "xsuite/xtrack" ]]; then
   # Run tests one by one
   pip install pytest-html-merger
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/bash
+
+# Expects the path to tests folder as the first argument
+if [ $# -eq 0 ]; then
+    echo "No arguments provided. Please provide the path to the tests folder."
+    exit 1
+fi
+
+# Install pytest-html for generating reports
+pip install pytest-html
+
+# Set the path to the reports folder
+REPORTS_DIR="/opt/reports"
+
+# Keep track of failures
+STATUS=0
+
+# If on Pyopencl context, run tests one by one, otherwise run normally
+if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextPyopencl" ]]; then
+  # Run tests one by one
+  pip install pytest-html-merger
+
+  for test_file in "$@"/test_*; do
+      TEST_NAME=$(basename "$test_file" .py)  # strip path and extension
+      echo "Running test $TEST_NAME..."
+      pytest \
+        --color=yes \
+        --verbose \
+        --html="$REPORTS_DIR/report-$TEST_NAME.html" --self-contained-html \
+        "$test_file" || STATUS=1
+  done
+
+  echo "Generating report..."
+  pytest_html_merger -i "$REPORTS_DIR" -o "$REPORTS_DIR/report.html"
+else
+   # Run tests normally if no Pyopencl context
+  pytest \
+    --color=yes \
+    --verbose \
+    --html="$REPORTS_DIR/report.html" --self-contained-html \
+    "$@" || STATUS=1
+fi
+
+exit $STATUS


### PR DESCRIPTION
## Description

When running Xtrack tests on `ContextPyopencl`, run each file separately to avoid the `OUT_OF_HOST_MEMORY` OpenCL error, whose cause is still unclear.