### PR TITLE
Use dynamic swap space to prevent catastrophic test failures

### DIFF
--- a/.github/workflows/manual_test_gh.yaml
+++ b/.github/workflows/manual_test_gh.yaml
@@ -60,3 +60,4 @@ jobs:
       xmask_location: ${{ inputs.xmask_location }}
       xcoll_location: ${{ inputs.xcoll_location }}
       precompile_kernels: ${{ inputs.precompile_kernels }}
+      xobjects_test_contexts: ${{ inputs.xobjects_test_contexts }}

--- a/.github/workflows/test_gh.yaml
+++ b/.github/workflows/test_gh.yaml
@@ -64,14 +64,12 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - name: Increase swapfile
+    - name: Set up dynamic swapping
       run: |
         sudo swapoff -a
-        sudo fallocate -l 12G /swapfile
-        sudo chmod 600 /swapfile
-        sudo mkswap /swapfile
-        sudo swapon /swapfile
-        sudo swapon --show
+        sudo apt-get install -y swapspace
+        sudo systemctl start swapspace.service
+        df -h
     - name: Setup Miniforge
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/test_gh.yaml
+++ b/.github/workflows/test_gh.yaml
@@ -67,7 +67,7 @@ jobs:
     - name: Increase swapfile
       run: |
         sudo swapoff -a
-        sudo fallocate -l 15G /swapfile
+        sudo fallocate -l 10G /swapfile
         sudo chmod 600 /swapfile
         sudo mkswap /swapfile
         sudo swapon /swapfile

--- a/.github/workflows/test_gh.yaml
+++ b/.github/workflows/test_gh.yaml
@@ -67,7 +67,7 @@ jobs:
     - name: Increase swapfile
       run: |
         sudo swapoff -a
-        sudo fallocate -l 10G /swapfile
+        sudo fallocate -l 12G /swapfile
         sudo chmod 600 /swapfile
         sudo mkswap /swapfile
         sudo swapon /swapfile


### PR DESCRIPTION
## Description

Currently the tests are not running properly because the GitHub runners are running out of disk space already installing dependencies. This is because most disk space is configured as swap, as previously we were running out of RAM. This installs a package that will allocate swap on demand to alleviate these issues.

It is likely to not help fix all the issues, however at least some tests will run.

