### PR TITLE
Run self-hosted CPU tests daily

### DIFF
--- a/.github/workflows/cron_test_gpu_cl.yaml
+++ b/.github/workflows/cron_test_gpu_cl.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   run-tests-cron-gpu:
     if: github.repository == 'xsuite/xsuite'
-    uses: ./.github/workflows/test_gpu.yaml
+    uses: ./.github/workflows/test_sh.yaml
     with:
       xobjects_location: 'xsuite:main'
       xdeps_location: 'xsuite:main'

--- a/.github/workflows/cron_test_sh_cpu.yaml
+++ b/.github/workflows/cron_test_sh_cpu.yaml
@@ -1,5 +1,5 @@
 # This is a workflow that should run daily
-name: Daily test (self-hosted, CUDA)
+name: Daily test (self-hosted, CPU)
 
 # Controls when the action will run.
 on:
@@ -9,7 +9,7 @@ on:
 # This workflow calls the test_gpu.yaml workflow passing the default
 # branches as inputs. The cron workflow will not run on forks.
 jobs:
-  run-tests-cron-gpu:
+  run-tests-cron-sh-cpu:
     if: github.repository == 'xsuite/xsuite'
     uses: ./.github/workflows/test_sh.yaml
     with:
@@ -20,5 +20,5 @@ jobs:
       xfields_location: 'xsuite:main'
       xmask_location: 'xsuite:main'
       xcoll_location: 'xsuite:main'
-      test_contexts: 'ContextCupy'
-      platform: 'ubuntu'
+      test_contexts: 'ContextCpu;ContextCpu:auto'
+      platform: 'alma-cpu'

--- a/.github/workflows/manual_test_sh.yaml
+++ b/.github/workflows/manual_test_sh.yaml
@@ -1,5 +1,5 @@
 # This is a test workflow that is manually triggered
-name: Manual test (self-hosted, GPU)
+name: Manual test (self-hosted)
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
@@ -45,11 +45,11 @@ on:
         default: 'ubuntu'
         required: true
 
-# This workflow calls the test_gpu.yaml workflow passing the specified
+# This workflow calls the test_sh.yaml workflow passing the specified
 # branches as inputs
 jobs:
-  run-tests-manual-gpu:
-    uses: ./.github/workflows/test_gpu.yaml
+  run-tests-manual-sh:
+    uses: ./.github/workflows/test_sh.yaml
     secrets: inherit
     with:
       xobjects_location: ${{ inputs.xobjects_location }}

--- a/.github/workflows/test_gpu.yaml
+++ b/.github/workflows/test_gpu.yaml
@@ -35,6 +35,9 @@ on:
         required: true
         type: string
 
+env:
+  with_gpu: ${{ contains(inputs.test_contexts, 'Cupy') || contains(inputs.test_contexts, 'Pyopencl') }}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 # The jobs are all run in independent environments. Here we will run a separate job
 # for each of the test suites specified in the matrix below.
@@ -71,6 +74,7 @@ jobs:
             --build-arg xfields_branch=${xfields_branch} \
             --build-arg xmask_branch=${xmask_branch} \
             --build-arg xcoll_branch=${xcoll_branch} \
+            --build-arg with_gpu=${with_gpu} \
             -t $IMAGE .
 
   # Print out some stuff about the test environment
@@ -81,8 +85,10 @@ jobs:
       image_id: ${{ needs.build-test-image.outputs.image_id }}
     steps:
       - name: CUDA info
+        if: ${{ env.with_gpu == 'true' }}
         run: docker run --rm --gpus all ${image_id} nvidia-smi
       - name: OpenCL info
+        if: ${{ env.with_gpu == 'true' }}
         run: docker run --rm --gpus all ${image_id} clinfo
       - name: Package paths
         run: docker run --rm --gpus all ${image_id} python3 /opt/xsuite/xtrack/examples/print_package_paths.py

--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -1,5 +1,5 @@
 # This is a test workflow the other (self-hosted runner based) workflows rely on
-name: Test workflow (self-hosted, GPU)
+name: Test workflow (self-hosted)
 
 # Controls when the action will run. This is a reusable workflow.
 on:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,16 @@ ARG xtrack_branch=xsuite:main
 ARG xfields_branch=xsuite:main
 ARG xmask_branch=xsuite:main
 ARG xcoll_branch=xsuite:main
+ARG with_gpu
 
 # Use bash as the default shell
 SHELL ["/usr/bin/bash", "-c"]
 
 # Set up the OpenCL profile
-RUN mkdir -p /etc/OpenCL/vendors \
-    && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+RUN if [[ "with_gpu" == true ]]; then \
+        mkdir -p /etc/OpenCL/vendors \
+        && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd; \
+    fi
 
 WORKDIR /opt
 
@@ -39,12 +42,20 @@ RUN echo "mamba activate xsuite" >> ~/.bashrc
 # - cython is needed for cffi
 # - pytest-html for generating html reports
 # - gpyfft is a clfft wrapper that can only be installed from source or .deb
-RUN mamba install git pip compilers cupy cudatoolkit ocl-icd-system clinfo clfft \
-    && mamba clean -afy
-RUN pip install --no-cache-dir cython pyopencl mako gitpython pytest-html \
+RUN mamba install git pip compilers openmp && mamba clean -afy
+RUN pip install --no-cache-dir cython gitpython pytest-html \
     && dnf clean all \
     && rm -rf /var/cache/yum
-RUN git clone --depth 1 https://github.com/geggo/gpyfft.git && pip install ./gpyfft
+
+RUN if [[ "$with_gpu" == true ]]; then \
+        mamba install cupy cudatoolkit ocl-icd-system clinfo clfft \
+        && mamba clean -afy \
+        && pip install --no-cache-dir pyopencl mako \
+        && dnf clean all \
+        && rm -rf /var/cache/yum \
+        && git clone --depth 1 https://github.com/geggo/gpyfft.git \
+        && pip install ./gpyfft; \
+    fi
 
 # Install all the Xsuite packages in the required versions
 WORKDIR /opt/xsuite


### PR DESCRIPTION
## Description

This adds a workflow for CPU daily tests, renames the GPU workflows to simply self-hosted, adds some logic to not install GPU dependencies when not necessary.

Needs xsuite/xtrack#405 to be merged first.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
