### PR TITLE
Test xmask on CPU only, allow selection of suites

### DIFF
--- a/.github/workflows/cron_test_sh_cpu.yaml
+++ b/.github/workflows/cron_test_sh_cpu.yaml
@@ -22,3 +22,4 @@ jobs:
       xcoll_location: 'xsuite:main'
       test_contexts: 'ContextCpu;ContextCpu:auto'
       platform: 'alma-cpu'
+      suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xmask", "xcoll"]'

--- a/.github/workflows/manual_test_sh.yaml
+++ b/.github/workflows/manual_test_sh.yaml
@@ -44,6 +44,11 @@ on:
         description: platform
         default: 'ubuntu'
         required: true
+      suites:
+        description: test suites (JSON array string)
+        required: true
+        type: string
+        default: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xmask", "xcoll"]'
 
 # This workflow calls the test_sh.yaml workflow passing the specified
 # branches as inputs
@@ -61,3 +66,4 @@ jobs:
       xcoll_location: ${{ inputs.xcoll_location }}
       test_contexts: ${{ inputs.test_contexts }}
       platform: ${{ inputs.platform }}
+      suites: ${{ inputs.suites }}

--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -34,6 +34,11 @@ on:
       platform:
         required: true
         type: string
+      suites:
+        description: a list of the suites to run as a JSON string
+        required: false
+        type: string
+        default: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll"]'
 
 env:
   with_gpu: ${{ contains(inputs.test_contexts, 'Cupy') || contains(inputs.test_contexts, 'Pyopencl') }}
@@ -102,14 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-suite:
-        - xobjects
-        - xdeps
-        - xpart
-        - xtrack
-        - xfields
-        - xmask
-        - xcoll
+        test-suite: ${{ fromJson(inputs.suites) }}
 
     steps:
     - name: Run pytest


### PR DESCRIPTION
## Description

Test xmask only on CPU and skip it for GPU. Suites to run can be specified for the manual self-hosted workflow, however for now they have to be passed as a proper json string.