### PR TITLE
Increase the time limit on self-hosted test job

### DIFF
--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -104,6 +104,7 @@ jobs:
   run-tests:
     runs-on: [self-hosted, "${{ inputs.platform }}"]
     needs: [build-test-image, image-sanity-checks]
+    timeout-minutes: 540
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Xtrack tests currently take around 5h 50m on the GitHub runner, and timeout (at 6h) on the less powerful CPU self-hosted runner we use. We can increase the timeout delay on self-hosted runners, and this increases it by half.
