### PR TITLE
Add run name to manual workflow, allow specifying workflow branches

### DIFF
--- a/.github/workflows/manual_test_sh.yaml
+++ b/.github/workflows/manual_test_sh.yaml
@@ -1,6 +1,6 @@
 # This is a test workflow that is manually triggered
 name: Manual test (self-hosted)
-run-name: Manual test (self-hosted, ${{ inputs.platform }})
+run-name: Manual test (${{ inputs.platform }}, ${{ inputs.test_contexts }})
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.

--- a/.github/workflows/manual_test_sh.yaml
+++ b/.github/workflows/manual_test_sh.yaml
@@ -1,5 +1,6 @@
 # This is a test workflow that is manually triggered
 name: Manual test (self-hosted)
+run-name: Manual test (self-hosted, ${{ inputs.platform }})
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.

--- a/run_on_gh.py
+++ b/run_on_gh.py
@@ -74,7 +74,13 @@ def make_flag(pkg):
     help='The workflow file to use.',
     show_default=True,
 )
-def run(xo, xd, xp, xt, xf, xm, xc, platform, ctx, suites, wf):
+@click.option(
+    '--branch',
+    default='main',
+    help='The branch of the workflow.',
+    show_default=True,
+)
+def run(xo, xd, xp, xt, xf, xm, xc, platform, ctx, suites, wf, branch):
     """Schedule a test run of Xsuite on a self-hosted runner.
 
     Example:
@@ -111,7 +117,7 @@ def run(xo, xd, xp, xt, xf, xm, xc, platform, ctx, suites, wf):
     print('Scheduling')
     print(json.dumps(parameters, indent=2))
 
-    workflow_command = f'gh workflow run {wf} --json'
+    workflow_command = f'gh workflow run {wf} --json --ref {branch}'
 
     res = subprocess.run(
         workflow_command.split(),

--- a/run_release_tests.sh
+++ b/run_release_tests.sh
@@ -1,9 +1,11 @@
 set -e # Exit immediately if a command exits with a non-zero status.
 
+WF_BRANCH="main"
+
 XOBJECTS=xsuite:main
    XPART=xsuite:main
    XDEPS=xsuite:main
-  XTRACK=xsuite:release/0.46.4
+  XTRACK=xsuite:main
  XFIELDS=xsuite:main
    XMASK=xsuite:main
    XCOLL=xsuite:main
@@ -11,10 +13,14 @@ XOBJECTS=xsuite:main
 python run_on_gh.py --suites xo,xp,xd,xt,xf,xc --platform ubuntu --ctx cpu \
   --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK
 python run_on_gh.py --suites xm --platform alma-cpu --ctx cpu \
-  --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK
+  --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK --branch $WF_BRANCH
 python run_on_gh.py --suites xo,xp,xd,xt,xf,xc --platform  alma-cpu --ctx cpu:auto \
-   --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK
+   --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK --branch $WF_BRANCH
+python run_on_gh.py --suites xo,xp,xd,xt,xf,xc --platform ubuntu --ctx cpu \
+  --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK --branch $WF_BRANCH
 python run_on_gh.py --suites xo,xp,xd,xt,xf,xc --platform alma --ctx cuda \
-  --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK
+  --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK --branch $WF_BRANCH
 python run_on_gh.py --suites xo,xp,xd,xt,xf,xc --platform ubuntu --ctx cl \
-   --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK
+   --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK --branch $WF_BRANCH
+# python run_on_gh.py --suites xo,xp,xd,xt,xf,xc --platform radeon --ctx cl \
+#   --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK --branch $WF_BRANCH

--- a/run_release_tests.sh
+++ b/run_release_tests.sh
@@ -11,7 +11,7 @@ XOBJECTS=xsuite:main
    XCOLL=xsuite:main
 
 python run_on_gh.py --suites xo,xp,xd,xt,xf,xc --platform ubuntu --ctx cpu \
-  --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK
+  --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK --branch $WF_BRANCH
 python run_on_gh.py --suites xm --platform alma-cpu --ctx cpu \
   --xo $XOBJECTS --xp $XPART --xd $XDEPS --xt $XTRACK --xf $XFIELDS --xm $XMASK --branch $WF_BRANCH
 python run_on_gh.py --suites xo,xp,xd,xt,xf,xc --platform  alma-cpu --ctx cpu:auto \


### PR DESCRIPTION
## Description

Display *Manual test ([platform], [contexts])* on the workflow run. Add a `--branch [name]` flag to `run_on_gh.py` script to allow specifying the branch of xsuite/xsuite from which to take the workflow files.
