### PR TITLE
Add examples to line for `cut_at_s` and `transform_compound`

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 _build
+generated_code_snippets/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,7 +224,11 @@ snippet_files = {
     'xtrack/examples/radial_steering/000_radial_steering.py':
         'generated_code_snippets/radial_steering.py',
     'xtrack/examples/taylor_map/000_line_with_maps.py':
-        'generated_code_snippets/line_with_maps.py'
+        'generated_code_snippets/line_with_maps.py',
+    'xtrack/examples/compounds/001_compound_transform.py':
+        'generated_code_snippets/compound_transform.py',
+    'xtrack/examples/toy_ring/007_cut_at_s.py':
+        'generated_code_snippets/cut_at_s.py'
 }
 
 for ss, tt in snippet_files.items():

--- a/docs/line.rst
+++ b/docs/line.rst
@@ -5,6 +5,8 @@ Line
 .. contents:: Table of Contents
     :depth: 3
 
+.. _createline:
+
 Creating a Line object
 ======================
 
@@ -137,4 +139,24 @@ following example.
 See also :meth:`xtrack.SecondOrderTaylorMap.from_line`.
 
 .. literalinclude:: generated_code_snippets/line_with_maps.py
+   :language: python
+
+Apply transformations (tilt, shift) to compound elements
+========================================================
+
+The method :meth:`xtrack.Line.transform_compound` allows for applying
+transformations (rotations, shifts) to compound elements. See the following
+small example:
+
+.. literalinclude:: generated_code_snippets/compound_transform.py
+   :language: python
+
+Cut a line at some given s positions
+====================================
+
+The method :meth:`xtrack.Line.cut_at_s` allows for cutting the line at the
+specified s positions. In the example before we take the same toy ring introduced
+in the :ref:`earlier example<createline>` and we cut it into 100 equal length slices:
+
+.. literalinclude:: generated_code_snippets/cut_at_s.py
    :language: python


### PR DESCRIPTION
## Description

Add examples to line for `Line.cut_at_s` and `Line.transform_compound`.

Requires xsuite/xtrack#452.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
