### PR TITLE
Separate Xmask tests on self-hosted CPU workflow

### DIFF
--- a/.github/workflows/cron_test_sh_cpu.yaml
+++ b/.github/workflows/cron_test_sh_cpu.yaml
@@ -9,7 +9,7 @@ on:
 # This workflow calls the test_gpu.yaml workflow passing the default
 # branches as inputs. The cron workflow will not run on forks.
 jobs:
-  run-tests-cron-sh-cpu:
+  run-tests-cron-sh-cpu-no-xmask:
     if: github.repository == 'xsuite/xsuite'
     uses: ./.github/workflows/test_sh.yaml
     with:
@@ -22,4 +22,18 @@ jobs:
       xcoll_location: 'xsuite:main'
       test_contexts: 'ContextCpu;ContextCpu:auto'
       platform: 'alma-cpu'
-      suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xmask", "xcoll"]'
+      suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll"]'
+  run-tests-cron-sh-cpu-xmask:
+    if: github.repository == 'xsuite/xsuite'
+    uses: ./.github/workflows/test_sh.yaml
+    with:
+      xobjects_location: 'xsuite:main'
+      xdeps_location: 'xsuite:main'
+      xpart_location: 'xsuite:main'
+      xtrack_location: 'xsuite:main'
+      xfields_location: 'xsuite:main'
+      xmask_location: 'xsuite:main'
+      xcoll_location: 'xsuite:main'
+      test_contexts: 'ContextCpu;ContextCpu:auto'
+      platform: 'alma-cpu'
+      suites: '["xmask"]'


### PR DESCRIPTION
## Description

Separate Xsuite self-hosted CPU tests into two jobs, one for just Xmask, the other everything else. Currently the tests are timing out because the job time limit is hit: this should fix it.
