### PR TITLE
Separate self-hosted CPU into serial and parallel jobs

### DIFF
--- a/.github/workflows/cron_test_sh_cpu.yaml
+++ b/.github/workflows/cron_test_sh_cpu.yaml
@@ -9,7 +9,7 @@ on:
 # This workflow calls the test_gpu.yaml workflow passing the default
 # branches as inputs. The cron workflow will not run on forks.
 jobs:
-  run-tests-cron-sh-cpu-no-xmask:
+  run-tests-cron-sh-cpu-no-xmask-serial:
     if: github.repository == 'xsuite/xsuite'
     uses: ./.github/workflows/test_sh.yaml
     with:
@@ -20,7 +20,21 @@ jobs:
       xfields_location: 'xsuite:main'
       xmask_location: 'xsuite:main'
       xcoll_location: 'xsuite:main'
-      test_contexts: 'ContextCpu;ContextCpu:auto'
+      test_contexts: 'ContextCpu'
+      platform: 'alma-cpu'
+      suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll"]'
+  run-tests-cron-sh-cpu-no-xmask-openmp:
+    if: github.repository == 'xsuite/xsuite'
+    uses: ./.github/workflows/test_sh.yaml
+    with:
+      xobjects_location: 'xsuite:main'
+      xdeps_location: 'xsuite:main'
+      xpart_location: 'xsuite:main'
+      xtrack_location: 'xsuite:main'
+      xfields_location: 'xsuite:main'
+      xmask_location: 'xsuite:main'
+      xcoll_location: 'xsuite:main'
+      test_contexts: 'ContextCpu:auto'
       platform: 'alma-cpu'
       suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll"]'
   run-tests-cron-sh-cpu-xmask:


### PR DESCRIPTION
## Description

Separate the self-hosted CPU workflow further, as it's still running out of time. Now we have:
- xsuite, no xmask, serial
- xsuite, no xmask, openmp
- xmask
