### PR TITLE
Add SELinux remark to developer documentation

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -235,6 +235,9 @@ Nvidia device files:
    sudo semanage fcontext -a -t container_file_t '/dev/nvidia.*'
    restorecon -v /dev/*
 
+Note that it may be necessary to relabel the device files with the ``restorecon`` 
+command in the case of changes/updates to the hypervisor.
+
 Check that everything works with:
 
 .. code:: bash


### PR DESCRIPTION
## Description

An intervention to update the hypervisor necessitated moving the machines to a different one. After this was accomplished the GPU became inaccessible under podman in one of the testing machines. I traced the issue to a wrong SELinux labelling of device files, and a simple relabelling fixed the issue. Nevertheless, I add this remark to the guide in case this happens again.