### PR TITLE
Split different test CPU scenarios among different runners

### DIFF
--- a/.github/workflows/cron_test_sh_cpu.yaml
+++ b/.github/workflows/cron_test_sh_cpu.yaml
@@ -14,19 +14,19 @@ jobs:
     uses: ./.github/workflows/test_sh.yaml
     with:
       test_contexts: 'ContextCpu'
-      platform: 'alma-cpu'
+      platform: 'alma-cpu-smaller'
       suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll"]'
   run-tests-cron-sh-cpu-no-xmask-openmp:
     if: github.repository == 'xsuite/xsuite'
     uses: ./.github/workflows/test_sh.yaml
     with:
       test_contexts: 'ContextCpu:auto'
-      platform: 'alma-cpu'
+      platform: 'alma-cpu-1'
       suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll"]'
   run-tests-cron-sh-cpu-xmask:
     if: github.repository == 'xsuite/xsuite'
     uses: ./.github/workflows/test_sh.yaml
     with:
       test_contexts: 'ContextCpu;ContextCpu:auto'
-      platform: 'alma-cpu'
+      platform: 'alma-cpu-2'
       suites: '["xmask"]'


### PR DESCRIPTION
## Description

Run different self-hosted test scenarios on different runners. Currently the workflows just takes too much time: this should help.