### PR TITLE
Assign smaller cpu runner in cron to xmask, avoid mem issue in no-xmask

### DIFF
--- a/.github/workflows/cron_test_sh_cpu.yaml
+++ b/.github/workflows/cron_test_sh_cpu.yaml
@@ -14,19 +14,19 @@ jobs:
     uses: ./.github/workflows/test_sh.yaml
     with:
       test_contexts: 'ContextCpu'
-      platform: 'alma-cpu-smaller'
+      platform: 'alma-cpu-1'
       suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll"]'
   run-tests-cron-sh-cpu-no-xmask-openmp:
     if: github.repository == 'xsuite/xsuite'
     uses: ./.github/workflows/test_sh.yaml
     with:
       test_contexts: 'ContextCpu:auto'
-      platform: 'alma-cpu-1'
+      platform: 'alma-cpu-2'
       suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll"]'
   run-tests-cron-sh-cpu-xmask:
     if: github.repository == 'xsuite/xsuite'
     uses: ./.github/workflows/test_sh.yaml
     with:
       test_contexts: 'ContextCpu;ContextCpu:auto'
-      platform: 'alma-cpu-2'
+      platform: 'alma-cpu-smaller'
       suites: '["xmask"]'


### PR DESCRIPTION
## Description

Currently the job `run-tests-cron-sh-cpu-no-xmask-serial` runs out of memory on xtrack+xfields. Let's rearrange the runners and assign a bigger runner to this one, and the smaller one to xmask (which is sufficient from my tests).
