### PR TITLE
Pin numpy<2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires = [
     "xobjects==0.4.2",
     "xdeps==0.6.1",
     "xpart==0.18.4",
+    "numpy<2.0",
 ]
 build-backend = 'setuptools.build_meta'
 


### PR DESCRIPTION
## Description

The changes introduced in numpy 2.0 cause twiss to break at the moment. Before we figure out exactly how to fix it, let's pin numpy to the older version.