### PR TITLE
Downgrade numpy to <2.0 on pyopencl

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -12,6 +12,12 @@ REPORTS_DIR="/opt/reports"
 # Keep track of failures
 STATUS=0
 
+# A temporary workaround for pyopencl not supporting numpy 2 in wheels
+# TODO: Remove once pyopencl gets updated wheels
+if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextPyopencl" ]]; then
+  pip install 'numpy<2.0'
+fi
+
 # If xtrack on Pyopencl context, run tests one by one, otherwise run normally
 if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextPyopencl" ]] && [[ $* =~ xsuite/(xtrack|xpart|xfields) ]]; then
   # Run tests one by one


### PR DESCRIPTION
## Description

When tests are being run on the PyOpenCL context, downgrade Numpy to a supported version. This should be removed as soon as a compatible release of PyOpenCL appears.