### PR TITLE
Don't downgrade Numpy on PyOpenCL

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -12,12 +12,6 @@ REPORTS_DIR="/opt/reports"
 # Keep track of failures
 STATUS=0
 
-# A temporary workaround for pyopencl not supporting numpy 2 in wheels
-# TODO: Remove once pyopencl gets updated wheels
-if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextPyopencl" ]]; then
-  pip install 'numpy<2.0'
-fi
-
 # If xtrack on Pyopencl context, run tests one by one, otherwise run normally
 if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextPyopencl" ]] && [[ $* =~ xsuite/(xtrack|xpart|xfields) ]]; then
   # Run tests one by one


### PR DESCRIPTION
PyOpenCL now has wheels supporting Numpy 2.0: https://github.com/inducer/pyopencl/releases/tag/v2024.2.7. There is no longer a need for this workaround.

This reverts commit 7ba72f4b6c82eb7da3495114d67fa71ac7c1c2c1, reversing changes made to 123f3e0c760e4c27721902681aa65a22cec6374e.