### PR TITLE
When no tests collected don't count it as a failure

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -24,18 +24,28 @@ if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextPyopencl" ]] && [[ $* =~ xsuite/(xtrack
         --color=yes \
         --verbose \
         --html="$REPORTS_DIR/report-$TEST_NAME.html" --self-contained-html \
-        "$test_file" || STATUS=1
+        "$test_file"
+      PYTEST_STATUS=$?
+      # If the tests failed, set the status to 1 (5 is for no tests collected)
+      if [ $PYTEST_STATUS -ne 0 ] && [ $PYTEST_STATUS -ne 5 ]; then
+        STATUS=1
+      fi
   done
 
   echo "Generating report..."
   pytest_html_merger -i "$REPORTS_DIR" -o "$REPORTS_DIR/report.html"
 else
-   # Run tests normally if no Pyopencl context
+  # Run tests normally if no Pyopencl context
   pytest \
     --color=yes \
     --verbose \
     --html="$REPORTS_DIR/report.html" --self-contained-html \
-    "$@" || STATUS=1
+    "$@"
+  PYTEST_STATUS=$?
+  # If the tests failed, set the status to 1 (5 is for no tests collected)
+  if [ $PYTEST_STATUS -ne 0 ] && [ $PYTEST_STATUS -ne 5 ]; then
+    STATUS=1
+  fi
 fi
 
 exit $STATUS


### PR DESCRIPTION
## Changes

Currently when some tests are deselected (e.g. using `-k` option), and it so happens that all tests in a suite are deselected (which is very easy on ContextPyopencl where we run tests file-by-file), pytest will return 5, and cause the test session to report as a failure. We catch this condition, and do not count it as a failure.