### PR TITLE
Adding BlowUp and EmittanceMonitor to prebuilt kernels

### DIFF
--- a/xsuite/kernel_definitions.py
+++ b/xsuite/kernel_definitions.py
@@ -109,7 +109,9 @@ DEFAULT_XCOLL_ELEMENTS = [
     xc.BlackAbsorber,
     xc.EverestBlock,
     xc.EverestCollimator,
-    xc.EverestCrystal
+    xc.EverestCrystal,
+    xc.BlowUp,
+    xc.EmittanceMonitor
 ]
 
 NON_TRACKING_ELEMENTS = [


### PR DESCRIPTION
## Description


## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
