### PR TITLE
Replace Mambaforge installer with Miniforge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,11 +47,11 @@ RUN cat /sys/class/drm/card*/device/vendor | grep 0x1002; \
 WORKDIR /opt
 
 # Install mamba and set up an environment
-RUN curl -OL https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
-RUN bash Mambaforge-Linux-x86_64.sh -b -p /opt/mambaforge
-RUN rm Mambaforge-Linux-x86_64.sh
+RUN curl -OL https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+RUN bash Miniforge3-Linux-x86_64.sh -b -p /opt/miniforge
+RUN rm Miniforge3-Linux-x86_64.sh
 
-ENV PATH /opt/mambaforge/bin:$PATH
+ENV PATH /opt/miniforge/bin:$PATH
 RUN mamba init bash
 RUN mamba create --name xsuite python=3.11
 RUN echo "mamba activate xsuite" >> ~/.bashrc


### PR DESCRIPTION
## Description

The Mambaforge installer we currently use will be discontinued from 2025: https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/. This replaces it with Miniforge, which is the same.

## Checklist

Mandatory: 

- n/a I have added tests to cover my changes
- n/a All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
