### PR TITLE
Don't depend on jq in tests as it's awkward on some runners

### DIFF
--- a/.github/workflows/test_gh.yaml
+++ b/.github/workflows/test_gh.yaml
@@ -70,8 +70,6 @@ jobs:
       run: |
         conda install openmp
         pip install cython
-    - name: Install jq
-      run: sudo apt-get install -y jq
     - name: Checkout xsuite
       uses: actions/checkout@v4
       with:
@@ -80,14 +78,13 @@ jobs:
       env:
         precompile_kernels: ${{ inputs.precompile_kernels }}
       run: |
-        echo '${{ inputs.locations }}' | jq '.' > locations.json
-        export xobjects_branch=$(jq -r '.["xobjects_location"]' locations.json) 
-        export xdeps_branch=$(jq -r '.["xdeps_location"]' locations.json)
-        export xpart_branch=$(jq -r '.["xpart_location"]' locations.json) 
-        export xtrack_branch=$(jq -r '.["xtrack_location"]' locations.json)
-        export xfields_branch=$(jq -r '.["xfields_location"]' locations.json) 
-        export xmask_branch=$(jq -r '.["xmask_location"]' locations.json)
-        export xcoll_branch=$(jq -r '.["xcoll_location"]' locations.json)
+        export xobjects_branch=${{ fromJson(inputs.locations).xobjects_location }} 
+        export xdeps_branch=${{ fromJson(inputs.locations).xobjects_location }}
+        export xpart_branch=${{ fromJson(inputs.locations).xpart_location }} 
+        export xtrack_branch=${{ fromJson(inputs.locations).xtrack_location }}
+        export xfields_branch=${{ fromJson(inputs.locations).xfields_location }} 
+        export xmask_branch=${{ fromJson(inputs.locations).xmask_location }}
+        export xcoll_branch=${{ fromJson(inputs.locations).xcoll_location }}
         export xsuite_prefix="$GITHUB_WORKSPACE" 
         bash $GITHUB_WORKSPACE/xsuite/.github/scripts/install_branches.sh
     - name: Precompile kernels

--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -48,34 +48,24 @@ jobs:
     outputs:
       image_id: ${{ steps.build-image.outputs.image_id }}
     steps:
-      - name: Install jq
-        run: |
-          if command -v jq &> /dev/null; then
-            echo "jq is already installed"
-          elif command -v apt-get &> /dev/null; then
-            sudo apt-get update && sudo apt-get install -y jq
-          else command -v yum &> /dev/null; 
-            sudo yum install -y jq
-          fi
       - id: checkout-repo
         name: Checkout the repo
         uses: actions/checkout@v3
       - id: build-image
         name: Build the test image
         run: |
-          echo '${{ inputs.locations }}' | jq '.' > locations.json
           IMAGE="xsuite-test-runner-$(cat /proc/sys/kernel/random/uuid)"
           echo "image_id=$IMAGE" >> $GITHUB_OUTPUT
           docker build \
             --network=host \
             --no-cache=true \
-            --build-arg xobjects_branch=$(jq -r '.["xobjects_location"]' locations.json) \
-            --build-arg xdeps_branch=$(jq -r '.["xdeps_location"]' locations.json) \
-            --build-arg xpart_branch=$(jq -r '.["xpart_location"]' locations.json) \
-            --build-arg xtrack_branch=$(jq -r '.["xtrack_location"]' locations.json) \
-            --build-arg xfields_branch=$(jq -r '.["xfields_location"]' locations.json) \
-            --build-arg xmask_branch=$(jq -r '.["xmask_location"]' locations.json) \
-            --build-arg xcoll_branch=$(jq -r '.["xcoll_location"]' locations.json) \
+            --build-arg xobjects_branch=${{ fromJson(inputs.locations).xobjects_location }} \
+            --build-arg xdeps_branch=${{ fromJson(inputs.locations).xobjects_location }} \
+            --build-arg xpart_branch=${{ fromJson(inputs.locations).xpart_location }} \
+            --build-arg xtrack_branch=${{ fromJson(inputs.locations).xtrack_location }} \
+            --build-arg xfields_branch=${{ fromJson(inputs.locations).xfields_location }} \
+            --build-arg xmask_branch=${{ fromJson(inputs.locations).xmask_location }} \
+            --build-arg xcoll_branch=${{ fromJson(inputs.locations).xcoll_location }} \
             --build-arg with_gpu=${with_gpu} \
             -t $IMAGE .
 


### PR DESCRIPTION
## Description

Currently we depend on `jq` in the runners for some configuration aspects of the workflow, but it's causing issues sometimes (not all platforms are happy with just letting the workflow install it on the system). We can accomplish the same task without `jq` though, so let's do that.