### PR TITLE
Return a proper return code instead of always 0 in 'Run pytest' step

### DIFF
--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -112,6 +112,7 @@ jobs:
           ${image_id} \
           /opt/run_tests.sh /opt/xsuite/${{ matrix.test-suite }}/tests \
             | tee reports/${{ matrix.test-suite }}/results.txt
+        return ${PIPESTATUS[0]}
 
     - name: Generate Summary Report
       run: bash .github/scripts/generate_summary.sh ${{ matrix.test-suite }} >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

Return the right status code in the 'Run tests' step.

After adding summaries, a bug was introduced: instead of getting the true return code from `run_tests.sh` in the 'Run tests' step of `test_sh.yaml`, success is always given instead. This is because the stdout of the command is piped through `tee`, and so the return code is the one of the pipe (which always succeeds in this case).