### PR TITLE
Add `--rm` option to `docker build`

### DIFF
--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -57,6 +57,7 @@ jobs:
           IMAGE="xsuite-test-runner-$(cat /proc/sys/kernel/random/uuid)"
           echo "image_id=$IMAGE" >> $GITHUB_OUTPUT
           docker build \
+            --rm \
             --network=host \
             --no-cache=true \
             --build-arg xobjects_branch=${{ fromJson(inputs.locations).xobjects_location }} \


### PR DESCRIPTION
## Description

This removes intermediate containers (apparently including storage containers under podman) after building, which should fix the problem of runners running out of storage.