### PR TITLE
Cancelled workflows: fix zombie container problem

### DIFF
--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -106,7 +106,7 @@ jobs:
         pytest_options: ${{ inputs.pytest_options }}
       run: |
         mkdir -p reports/${{ matrix.test-suite }}
-        docker run --rm --gpus all \
+        exec docker run --rm --gpus all \
           --env XOBJECTS_TEST_CONTEXTS="${test_contexts}" \
           --env PYTEST_ADDOPTS="${pytest_options}" \
           -v $PWD/reports/${{ matrix.test-suite }}:/opt/reports:Z \
@@ -130,10 +130,5 @@ jobs:
       image_id: ${{ needs.build-test-image.outputs.image_id }}
     if: always()
     steps:
-      - name: Stop the containers and remove the image
-        run: |
-          docker container stop \
-            $(docker ps -q --filter ancestor=${image_id}) || true
-          docker container rm --volumes \
-            $(docker ps -qa --filter ancestor=${image_id}) || true
-          docker image rm ${image_id}
+      - name: Clean up the image
+        run: docker image rm -f ${image_id}

--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -119,7 +119,7 @@ jobs:
     if: success() || failure()
     steps:
       - name: Wait
-        run: sleep 300
+        run: sleep 60
 
   # Cleanup after the tests by removing the image and making sure there are
   # no unused images and stopped containers


### PR DESCRIPTION
## Description

This resolves a long-standing problem where (under `podman` specifically) the test machines would gradually run out of storage.

### What was happening?

Interplay of three issues/features:

1. GitHub actions does not (by default) gracefully stop most jobs.

When a job is cancelled (be it by the user, or automatically, e.g. due to a timeout) the runner sends the SIGINT signal to the main process of the job, waits 7.5 seconds, then tries with SIGTERM, and when that fails to kill it, it sends SIGKILL to the entire process tree. Since most jobs are run through bash, which does not propagate signals to child processes, they never see the SIGINT/SIGTERM and get killed abruptly. (See https://github.com/orgs/community/discussions/26311).

2. The `run_tests.sh` script also did not propagate signals to the pytest process.

For the same reasons as above, since it is run as a bash script.

3. Podman does not run through a daemon.

When a container is launched with podman, multiple processes are spawned, most notably the container process itself and `conmon`, a monitoring process that orchestrates/supervises the container. If all of these processes are killed in a way that does not allow them a graceful exit, podman is left in an improper state. This could have been seen with `podman ps -a` on affected machines, where some containers would be stuck in `Stopping` state, and any attempt at killing/removing them would result in a message `Container in improper state`. Since the containers could not be removed, neither could their images (and build storage volumes!), and they would slowly, over time, eat the available storage.

### What is the fix?

1. Run the main job process with `exec`: this replaces the current shell with the process (our script in our case), so when GH cancels the job, the script receives the right signals.
2. Correctly propagate the signals in our script. This involves first registering a signal handler with `trap`. The trap will not be called though until the process in the foreground finishes, that why we have to put `pytest` in the background with `&` and then resynchronise with `wait`. In the trap handler we kill `pytest` with SIGKILL since there we don't care about a graceful shutdown, we want it gone as fast as we can.
3. Now, on cancellation, `podman` receives SIGINT, kills `pytest`, and terminates gracefully (provided nothing strange happens that makes it take 9 seconds -- we will sort that problem out if it comes). Since we run `docker`/`podman` with `--rm` we don't need to worry about stopping the container. We remove the image (with force) and in 9/10 cases we should have a very nice cleanup.

#### Caveats?

On Docker, since there is a daemon, killing `docker run --rm ...` process might not make it disappear immediately (maybe?). We leave the wait we had in the workflow already, but lets investigate if maybe it can be replaced with some more intelligent wait in the future... The delay is reduced, if 1 minute is not enough, then maybe we should investigate what is causing the problem anyway.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
