### PR TITLE
Specify explicitly the registry of the alma image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is a test runner Dockerfile. The branches used to
 # build our image can be specified using the --build-arg's below.
-FROM cern/alma9-base:latest
+FROM gitlab-registry.cern.ch/linuxsupport/alma9-base:latest
 LABEL author="Szymon Lopaciuk <szymon@lopaciuk.eu>"
 ENV PIP_ROOT_USER_ACTION=ignore
 ENV NVIDIA_VISIBLE_DEVICES=all


### PR DESCRIPTION
"Too many requests" reached on registry.docker.io. Let's switch to explicitly using gitlab-registry.cern.ch for the alma images.