### PR TITLE
Fixes in workflows: conditional gpu flag and no xdist on xmask

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -51,7 +51,8 @@ if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextPyopencl" ]] && [[ $* =~ xsuite/(xtrack
       fi
   done
 else  # Run tests normally if no Pyopencl context
-  if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextCpu" ]]; then
+  # Use multithreading if on cpu context and not xmask
+  if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextCpu" ]] && [[ ! $* =~ xsuite/xmask ]]; then
     pip install pytest-xdist
     PYTEST_OPTS="$PYTEST_OPTS -nauto"
   fi

--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -84,9 +84,9 @@ jobs:
         if: ${{ env.with_gpu == 'true' }}
         run: docker run --rm --gpus all ${image_id} clinfo
       - name: Package paths
-        run: docker run --rm ${image_id} python3 /opt/xsuite/xtrack/examples/print_package_paths.py
+        run: docker run --rm ${{ env.with_gpu == 'true' && '--gpus all' || '' }} ${image_id} python3 /opt/xsuite/xtrack/examples/print_package_paths.py
       - name: List dependencies
-        run: docker run --rm ${image_id} pip freeze
+        run: docker run --rm ${{ env.with_gpu == 'true' && '--gpus all' || '' }} ${image_id} pip freeze
 
   # Run the tests for each repo in parallel in a test container
   run-tests:

--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -84,9 +84,9 @@ jobs:
         if: ${{ env.with_gpu == 'true' }}
         run: docker run --rm --gpus all ${image_id} clinfo
       - name: Package paths
-        run: docker run --rm --gpus all ${image_id} python3 /opt/xsuite/xtrack/examples/print_package_paths.py
+        run: docker run --rm ${image_id} python3 /opt/xsuite/xtrack/examples/print_package_paths.py
       - name: List dependencies
-        run: docker run --rm --gpus all ${image_id} pip freeze
+        run: docker run --rm ${image_id} pip freeze
 
   # Run the tests for each repo in parallel in a test container
   run-tests:
@@ -106,7 +106,8 @@ jobs:
         pytest_options: ${{ inputs.pytest_options }}
       run: |
         mkdir -p reports/${{ matrix.test-suite }}
-        exec docker run --rm --gpus all \
+        exec docker run --rm \
+          ${{ env.with_gpu == 'true' && '--gpus all' || '' }} \
           --env XOBJECTS_TEST_CONTEXTS="${test_contexts}" \
           --env PYTEST_ADDOPTS="${pytest_options}" \
           -v $PWD/reports/${{ matrix.test-suite }}:/opt/reports:Z \


### PR DESCRIPTION
## Description

- Don't specify `--gpus all` unless needed (new machine is unhappy about this option)
- Don't run xmask tests multithreaded: the tests don't commute