### PR TITLE
Workflows: don't use pytest-xdist with xcoll, tests not independent

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -52,7 +52,7 @@ if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextPyopencl" ]] && [[ $* =~ xsuite/(xtrack
   done
 else  # Run tests normally if no Pyopencl context
   # Use multithreading if on cpu context and not xmask
-  if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextCpu" ]] && [[ ! $* =~ xsuite/xmask ]]; then
+  if [[ $XOBJECTS_TEST_CONTEXTS =~ "ContextCpu" ]] && [[ ! $* =~ xsuite/(xmask|xcoll) ]]; then
     pip install pytest-xdist
     PYTEST_OPTS="$PYTEST_OPTS -nauto"
   fi


### PR DESCRIPTION
## Description

Similarly to xfields, tests for xcoll are not independent and need to be run in a specific order. This disables xdist for xcoll.