### PR TITLE
Add RBend to kernel_definitions and fixes for Pyopencl workflows

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -35,8 +35,7 @@ export GITHUB_ACTIONS=true
 run_pytest() {
   pytest $PYTEST_OPTS "$1" &
   PYTEST_PID=$!
-  wait $PYTEST_PID
-  PYTEST_STATUS=$?
+  wait $PYTEST_PID || PYTEST_STATUS=$?
 }
 
 # If xtrack on Pyopencl context, run tests one by one, otherwise run normally

--- a/xsuite/kernel_definitions.py
+++ b/xsuite/kernel_definitions.py
@@ -89,6 +89,7 @@ ONLY_XTRACK_ELEMENTS = [
 
 NO_SYNRAD_ELEMENTS = [
     Bend,
+    RBend,
     Quadrupole,
     Sextupole,
     Octupole,


### PR DESCRIPTION
## Description

- Add `RBend` to `kernel_definitions.py`
- Fix a bug where if one Pyopencl test session (run in sequence per-file by default) fails, subsequent ones don't get executed.