### PR TITLE
Update installation.rst: no need to install OpenMP in most cases

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -280,9 +280,12 @@ And install gpyfft locally.
 Installation of OpenMP
 ----------------------
 
-If using a Mac (and/or the Clang compiler), inside of your conda environment run
-``conda install llvm-openmp``. On Linux, the same functionality (for GCC) is
-provided by ``conda install libgomp``.
+On Linux and on Apple Silicon Macs OpenMP support should automatically be
+provided with the conda-forge's ``compilers`` package. However, on Intel Macs
+it may be necessary to separately install the ``llvm-openmp`` package with
+``conda install llvm-openmp``. Similarly, should a manual installation on Linux
+be needed, the same functionality (for GCC) is provided by the ``libgomp``
+package for GCC.
 
 
 .. _miniforge:


### PR DESCRIPTION
## Description

Indeed, as mentioned in the issue below, it is not necessary to separately install `llvm-openmp` on Apple Silicon Macs, before being able to use OpenMP acceleration. This amends the guide to make it clear.

Closes xsuite/xsuite#608.

