### PR TITLE
Only run context-dependent tests on GPU nightly runs, log durations

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -19,11 +19,8 @@ _term() {
 }
 trap _term SIGINT SIGTERM
 
-# Set the path to the reports folder
-REPORTS_DIR="/opt/reports"
-
 # Pytest options
-PYTEST_OPTS="--color=yes --verbose $PYTEST_ADDOPTS"
+PYTEST_OPTS="--durations=0 --durations-min=1 --color=yes --verbose $PYTEST_ADDOPTS"
 
 # Keep track of failures
 STATUS=0

--- a/.github/workflows/cron_test_gpu_cl.yaml
+++ b/.github/workflows/cron_test_gpu_cl.yaml
@@ -16,3 +16,4 @@ jobs:
       test_contexts: 'ContextPyopencl'
       platform: 'alma'
       suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll"]'
+      pytest_options: '-m context_dependent'

--- a/.github/workflows/cron_test_gpu_cuda.yaml
+++ b/.github/workflows/cron_test_gpu_cuda.yaml
@@ -16,3 +16,4 @@ jobs:
       test_contexts: 'ContextCupy'
       platform: 'ubuntu'
       suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll"]'
+      pytest_options: '-m context_dependent'


### PR DESCRIPTION
## Description

- Only run context-dependent tests on GPU nightly runs
- Log durations of all the tests at the end of the session
