### PR TITLE
Workflows: updates for Mamba v2, use Python 3.12 now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,8 @@ RUN bash Miniforge3-Linux-x86_64.sh -b -p /opt/miniforge
 RUN rm Miniforge3-Linux-x86_64.sh
 
 ENV PATH /opt/miniforge/bin:$PATH
-RUN mamba init bash
-RUN mamba create --name xsuite python=3.11
-RUN echo "mamba activate xsuite" >> ~/.bashrc
+RUN mamba create --name xsuite python=3.12 && mamba shell init -s bash
+SHELL ["mamba", "run", "-n", "xsuite", "/bin/bash", "-c"]
 
 # Install dependencies (compilers, OpenCL and CUDA packages, test requirements)
 # - mako is an optional requirement of pyopencl that we need


### PR DESCRIPTION
## Description

Mamba v2 update changed some CLI, this brings the workflows in line with them, also take the opportunity to use Python 3.12 now.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
