### PR TITLE
typo in frequency-k relation of cavity in physics manual

### DIFF
--- a/docs/physics_manual/xtrack.tex
+++ b/docs/physics_manual/xtrack.tex
@@ -935,7 +935,7 @@ a_s(x,y)&=\frac{c_1}{1 + h x} + f(x,y) -
 
 \subsection{Accelerating Cavity}
 
-The approximated energy gain of a particle passing through an electric field of frequency $f=\frac{k}{2\pi c}$ for which:
+The approximated energy gain of a particle passing through an electric field of frequency $f=\frac{kc}{2\pi}$ for which:
 \begin{align}
 V \sin(\phi - k \tau) = \int_{-l/2}^{l/2} E_s(0,0,t,s)  {\rm \,d}s.
 \end{align}


### PR DESCRIPTION
In section: 1.5.5. Accelerating Cavity 
The frequency $f = \frac{k}{2\pi c}$ should instead read $f = \frac{kc}{2\pi}$.


## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
