### PR TITLE
Updates for CI/CD workflows

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -23,6 +23,7 @@ trap _term SIGINT SIGTERM
 PYTEST_OPTS="--durations=0 --durations-min=1 --color=yes --verbose $PYTEST_ADDOPTS"
 
 # Keep track of failures
+PYTEST_STATUS=0
 STATUS=0
 
 # Make nice annotations in the GitHub Actions logs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,15 +12,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
-        pyver: [cp310, cp311, cp312, cp313]
-        # exclude:
-        #   - os: macos-14
-        #     pyver: cp38
-        #   - os: macos-13
-        #     pyver: cp38
-        #   - os: ubuntu-latest
-        #     pyver: cp38
+        os: [
+          ubuntu-latest,
+          macos-13,  # x86_64 runners (deprecated) for building x86 wheels
+          macos-14,  # arm64 runners
+        ]
+        pyver: [cp310, cp311, cp312, cp313, cp314]
     steps:
       - uses: actions/checkout@v4
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ include pyproject.toml
 include *.md
 
 # Include the license file
-include LICENSE.txt
+include LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ authors = [
 description = "Integrated suite for particle accelerator simulations."
 readme = "README.md"
 requires-python = ">=3.10"
-license = {file = "LICENSE"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 dependencies = [
     "xtrack==0.96.2",
     "xfields==0.25.5",
@@ -43,43 +44,26 @@ Documentation = 'https://xsuite.readthedocs.io/'
 [project.scripts]
 xsuite-prebuild = "xsuite.cli:main"
 
+[project.optional-dependencies]
+notebooks = ['jupyter', 'ipympl', 'xplt']
+full_env = ['cpymad', 'nafflib', 'pytest', 'pytest-mock', 'jupyter', 'ipympl', 'xplt', 'ipython']
+
 [tool.setuptools_scm]
 # empty for default configuration
 
-# The very non-obvious way files can be included in either sdist or bdist with
-# setuptools. We need to list the file in:
-# - MANIFEST.in if we want it in both sdist and bdist,
-# - package_data and exclude it from the manifest if we want it in bdist only,
-# - exclude_package_data if we want it in sdist only,
-# - nowhere if we don't want to package them.
-# Thanks to this setup an sdist can be build without the binary files, and a
-# bdist can be build including them following the standard PEP 517 procedure
-# using the `build` command.
+# MANIFEST.in dictates which non-Python files are included in the sdist, and
+# there we implicitly exclude the prebuilt kernels.
+# As for the wheel (binary distribution), the prebuild kernels are created with
+# a custom build_ext command in setup.py, and are not subject to filtering by
+# `package-data` or `exclude-package-data`, so they will all be included.
 [tool.setuptools]
-packages = ["xsuite"]
-include-package-data = true
-
-[tool.setuptools.package-data]
-xsuite = [
-    'lib/*.so',
-    'lib/*.dylib',
-    'lib/*.dll',
-    'lib/*.json',
-]
+packages = ["xsuite", "xsuite.lib"]
 
 [tool.cibuildwheel]
 skip = [
-    # PyPy does not work for us
-    "pp*",
     # i686 is not needed or supported
     "*i686",
     # We don't need musl libc support
     "*musllinux*",
-    # Apparently there's a problem with with Python 3.8 on ARM64 macOS; the
-    # x86_64 version is run anyway pulling the x86 cffi library, building
-    # x86 dylibs that cannot then be imported properly by the ARM64 Python.
-    # Witnessed on here: https://github.com/pypa/cibuildwheel/issues/1278.
-    # It does not make 100% sense to me, but for now this is the workaround.
-    "cp38-macosx_arm64",
 ]
 build-verbosity = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    'setuptools>=64',
+    'setuptools>=77',
     'setuptools-scm[toml]>=8',
     "xtrack==0.96.2",
     "xfields==0.25.5",

--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,4 @@ setup(
     cmdclass={
         'build_ext': CustomBuildExtCommand,
     },
-    extras_require={
-        'notebooks': ['jupyter', 'ipympl', 'xplt'],
-        'full_env': ['cpymad', 'nafflib', 'pytest', 'pytest-mock',
-                     'jupyter', 'ipympl', 'xplt', 'ipython'],
-    },
 )


### PR DESCRIPTION
Miscellaneous fixes for testing and release workflows:
- little typo in `run_tests.sh` that caused a warning to be emitted
- with the fix in Xobjects running tests one by one for OpenCL should not be necessary
- build wheels for 3.14
- adapt to [PEP 639](https://peps.python.org/pep-0639/#project-source-metadata)
- simplify packaging configuration & do as much as possible in `pyproject.toml`