### PR TITLE
test dockerfile for pip 25.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN if [[ "$with_gpu" == true ]]; then \
         mamba install cupy cudatoolkit ocl-icd-system clinfo clfft \
         && mamba clean -afy \
         && pip install --no-cache-dir pyopencl mako \
-        && git clone --depth 1 https://github.com/geggo/gpyfft.git \
+        && git clone --depth 1 https://github.com/szymonlopaciuk/gpyfft.git \
         && pip install ./gpyfft; \
     fi
 


### PR DESCRIPTION
## Description

Temporarily use a forked version of `gpyfft` while waiting for the fix in https://github.com/geggo/gpyfft/pull/56.
