### PR TITLE
Increase timeout of run-tests to 12h

### DIFF
--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -102,7 +102,7 @@ jobs:
   run-tests:
     runs-on: [self-hosted, "${{ inputs.platform }}"]
     needs: [build-test-image, image-sanity-checks]
-    timeout-minutes: 540
+    timeout-minutes: 720
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Since OpenCL tests are running out of time, increase the timeout of the workflow.