### PR TITLE
Update gpyfft repository URL in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN if [[ "$with_gpu" == true ]]; then \
         mamba install cupy cudatoolkit ocl-icd-system clinfo clfft \
         && mamba clean -afy \
         && pip install --no-cache-dir pyopencl mako \
-        && git clone --depth 1 https://github.com/szymonlopaciuk/gpyfft.git \
+        && git clone --depth 1 https://github.com/geggo/gpyfft.git \
         && pip install ./gpyfft; \
     fi
 


### PR DESCRIPTION
## Description

Since a fix was merged in upstream of gpyfft repo, we can undo the pin of our fork in Dockerfile.