### PR TITLE
Increase timeout for run-tests job to 23h

### DIFF
--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -102,7 +102,7 @@ jobs:
   run-tests:
     runs-on: [self-hosted, "${{ inputs.platform }}"]
     needs: [build-test-image, image-sanity-checks]
-    timeout-minutes: 720
+    timeout-minutes: 1380
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Increase test timeout some more since it's still not enough for OpenCL