### PR TITLE
Build wheels for linux arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [
+          ubuntu-24.04-arm, 
           ubuntu-latest,
           macos-15-intel,  # x86_64 runners for building x86 wheels
           macos-latest,  # arm64 runners


### PR DESCRIPTION
This PR adds an arm64 runner for Linux in the release CI. This ensures that pre-built wheels are available for arm64 linux, which is also useful for speeding up installation in containers and VMs on MacOS.