### PR TITLE
Docs for new Xobjects C API, how to define prebuild kernels, auto deprecations

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,10 @@
 _build
 generated_code_snippets/
+xdeps/
+xobjects/
+xtrack/
+xpart/
+xfields/
+xcoll/
+xwakes/
+xmask/

--- a/docs/autogeneration.rst
+++ b/docs/autogeneration.rst
@@ -2,91 +2,139 @@ Code autogeneration
 ===================
 
 The xsuite library uses code autogeneration to specialize kernel code for the different contexts.
-Three contexts are presently available: ``cpu``, ``cuda``,  and ``opencl``.
+Three contexts are presently available: ``CPU``, ``CUDA``,  and ``OpenCL``.
 
 
-The developer writes a single C source code, providing additional information through the comment strings (annotations) described in the following.
+The developer writes a single C source code using the portability macros
+provided by ``xobjects/headers/common.h``. The preferred macro API includes
+``GPUFUN`` for functions callable on the GPU device, ``GPUKERN`` for kernels,
+``GPUGLMEM`` for pointers to GPU global memory, ``RESTRICT`` for restrict
+qualifiers, and ``VECTORIZE_OVER`` / ``END_VECTORIZE`` for context-dependent
+loops. Older sources may still use the comment strings described below; these
+legacy annotations are kept for compatibility but should not be used in new
+handwritten C code. With macros, typos are caught by the compiler instead of
+being silently ignored as unknown comments.
 
-``vectorize_over`` block
+``VECTORIZE_OVER`` block
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The syntax is the following:
+The preferred macro syntax is the following:
 
 .. code-block:: C
 
-    for (int myvar=0; myvar<myvarlim; myvar++){ //vectorize_over myvar myvarlim
+    VECTORIZE_OVER(myvar, myvarlim);
 
         [MY CODE]
 
-    }//end_vectorize
+    END_VECTORIZE;
 
-This is translated into a for loop in the CPU implementation and in a kernel function for the parallel implementations (cupy, pyopencl).
+This is translated into a for loop in the CPU implementation and into a
+single-particle block in the parallel implementations (cupy, pyopencl). Older
+sources may use the legacy ``//vectorize_over`` and ``//end_vectorize``
+comments for the same purpose.
 
-The generated cpu code will be:
+The corresponding CPU code will be:
 
 .. code-block:: C
 
     for (int myvar=0; myvar<myvarlim; myvar++){ //autovectorized
-
         [MY CODE]
+    } //end autovectorized
 
-        }//end autovectorized
-
-The generated CUDA code will be:
+The corresponding CUDA code will be:
 
 .. code-block:: C
 
     int myvar; //autovectorized
     myvar = blockDim.x * blockIdx.x + threadIdx.x; //autovectorized
     if (myvar<myvarlim) { //autovectorized
-
         [MY CODE]
+    } //end autovectorized
 
-    }//end autovectorized
-
-The corresponding generated OpenCL code will be:
+The corresponding OpenCL code will be:
 
 .. code-block:: C
 
     int myvar; //autovectorized
     myvar = get_global_id(0); //autovectorized
-
         [MY CODE]
-
     //end autovectorized
 
 
-``only_for_context`` directive
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``\\only_for_context`` directive can be used to include a givem line only for a certain context.
-For example with the following code the line marked line is included only in the GPU implementation.
+Context specific code guards
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Context-specific code should be guarded with the ``XO_CONTEXT_*`` macros
+defined by Xobjects at compile time. The available context macros are:
+
+``XO_CONTEXT_CPU``
+    Defined for both CPU contexts.
+
+``XO_CONTEXT_CPU_SERIAL``
+    Defined for the serial CPU context.
+
+``XO_CONTEXT_CPU_OPENMP``
+    Defined for the OpenMP CPU context.
+
+``XO_CONTEXT_CUDA``
+    Defined for the CUDA GPU context.
+
+``XO_CONTEXT_CL``
+    Defined for the OpenCL GPU context.
+
+For example, CPU-only code can be written as:
 
 .. code-block:: C
 
-    #include <atomicadd.h> //only_for_context cpu
+    #ifdef XO_CONTEXT_CPU
+    #include <math.h>
+    #endif
 
-``gpufun`` directive
-    ~~~~~~~~~~~~~~~~~~~~~
-    
-    The ``\*gpufun*\`` directive is used to qualify device functions. The code generator replaces it with ``__device__`` in the CUDA code.
-    
+and OpenMP-specific code can be written as:
 
-``gpukern`` directive
+.. code-block:: C
+
+    #ifdef XO_CONTEXT_CPU_OPENMP
+    #pragma omp parallel for
+    #endif
+
+Older sources may still use the legacy ``//only_for_context`` directive. New
+handwritten C code should use the ``XO_CONTEXT_*`` macros instead so that the
+code is more readable and so that the typos are caught by the compiler.
+
+``GPUFUN`` directive
+~~~~~~~~~~~~~~~~~~~~
+
+``GPUFUN`` marks a C function that can be called from the kernel code.
+On CUDA it expands to ``__device__``; on CPU it expands to ``static inline``.
+Use it for helper functions and element tracking functions that need to work
+across CPU and GPU contexts.
+
+Legacy C sources can use the ``/*gpufun*/`` directive for the same purpose. New
+code should include ``xobjects/headers/common.h`` and use the ``GPUFUN`` macro
+instead.
+
+``GPUKERN`` directive
 ~~~~~~~~~~~~~~~~~~~~~
 
-The ``\*gpukern*\`` directive is used to qualify kernel functions. The code generator replaces it with ``__global__`` in the CUDA code and with ``__kernel`` in the OpenCL code.
+``GPUKERN`` marks an entry-point kernel function launched by an Xobjects
+context. On CUDA it expands to ``__global__``; on OpenCL it expands to
+``__kernel``; on CPU it is empty.
+
+Legacy C sources can use the ``/*gpukern*/`` directive for the same purpose.
+New code should include ``xobjects/headers/common.h`` and use the ``GPUKERN``
+macro instead.
 
 
-``gpuglmem`` directive
+``GPUGLMEM`` directive
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``\*gpuglmem*\`` directive is used to qualify pointers to locations in the device global memoru. The code generator replaces it with ``__global`` in the OpenCL code.
+``GPUGLMEM`` marks a pointer as referring to global memory in GPU contexts. It
+expands to ``__global`` on OpenCL and is empty on CUDA and CPU.
 
-
-
-
-
-
+Legacy C sources can use the ``/*gpuglmem*/`` directive for the same purpose.
+New code should include ``xobjects/headers/common.h`` and use the ``GPUGLMEM``
+macro instead.
 
 
 

--- a/docs/dev_guide_xtbe_prebuilt_kernels.rst
+++ b/docs/dev_guide_xtbe_prebuilt_kernels.rst
@@ -1,0 +1,129 @@
+Prebuilt kernel definitions
+===========================
+
+Xsuite distributes prebuilt kernels for common tracking configurations. These
+kernels let users run many standard cases without compiling C code on first use.
+When a new beam element, helper structure, or package-level C source is added,
+the prebuilt-kernel definitions may need to be updated so that the generated
+kernel shared objects contain the required code.
+
+The definitions live in two places:
+
+* package-local ``prebuilt_kernel_definitions`` modules, which expose element
+  classes and optional constructor defaults;
+* ``xsuite/kernel_definitions.py``, which combines those package-local lists
+  into the actual prebuilt kernel configurations built by ``xsuite-prebuild``.
+
+Package-local definitions
+-------------------------
+
+Each package that contributes elements to the default Xsuite kernels keeps its
+own lists under ``<package>/prebuilt_kernel_definitions``. For example, Xtrack
+exports:
+
+.. code-block:: python
+
+    # xtrack/prebuilt_kernel_definitions/__init__.py
+    from .element_types import (
+        ONLY_XTRACK_ELEMENTS,
+        NO_SYNRAD_ELEMENTS,
+        NON_TRACKING_ELEMENTS,
+    )
+    from .element_inits import XTRACK_ELEMENTS_INIT_DEFAULTS
+
+The element-type module contains the classes to make available in prebuilt
+kernels. Tracking elements go in the lists used as ``classes`` in
+``xsuite/kernel_definitions.py``. Helper structures and elements that are not
+part of the line, but whose APIs or extra kernels need to be present, go in
+``extra_classes`` through a package-local list such as ``NON_TRACKING_ELEMENTS``.
+
+Some classes cannot be instantiated with an empty constructor. For those,
+provide minimal build-time arguments in the package-local
+``*_ELEMENTS_INIT_DEFAULTS`` dictionary:
+
+.. code-block:: python
+
+    XTRACK_ELEMENTS_INIT_DEFAULTS = {
+        'LimitPolygon': {
+            'x_vertices': np.array([0, 1, 1, 0]),
+            'y_vertices': np.array([0, 0, 1, 1]),
+        },
+    }
+
+These objects are only used to build representative trackers for kernel
+generation. Keep the defaults as small and inert as possible.
+
+Adding a class to Xsuite kernels
+--------------------------------
+
+After adding the class to the package-local definitions, make sure it is
+available in the appropriate configuration in ``xsuite/kernel_definitions.py``.
+For an existing Xsuite package this usually means adding the class to one of
+the lists already imported by ``xsuite/kernel_definitions.py``. For a new
+package, ``xsuite/kernel_definitions.py`` must import that package's
+prebuilt-kernel lists and include them in the selected configurations.
+
+Each entry has this shape:
+
+.. code-block:: python
+
+    ('default_base_config', {
+        'config': BASE_CONFIG,
+        'classes': XTRACK_ELEMENTS + DEFAULT_XFIELDS_ELEMENTS,
+        'extra_classes': [xt.Particles],
+    }),
+
+``classes``
+    Beam elements that are placed in the temporary ``xt.Line`` used to build the
+    tracker kernel.
+
+``extra_classes``
+    Xobjects classes that are not line elements for this configuration, but
+    whose C API or ``_kernels`` need to be compiled into the module.
+    ``xt.Particles`` is normally included here.
+
+``config``
+    Tracker configuration values used when building the prebuilt kernel. At run
+    time, prebuilt kernels are selected only when the requested config matches
+    the metadata exactly.
+
+The order of ``kernel_definitions`` matters. Runtime selection tries the entries
+in order and uses the first compatible prebuilt kernel, so more-specific or
+higher-priority definitions should stay above broader ones.
+
+Making C headers discoverable
+-----------------------------
+
+If a package provides C headers that are included by kernel sources, Xobjects
+needs to know where that package's sources are installed. Register an
+``xobjects`` entry point named ``include`` in the package's ``pyproject.toml``.
+
+.. code-block:: toml
+
+    [project.entry-points.xobjects]
+    include = "my_package"
+
+Xobjects loads entry points from the ``xobjects`` group with the name
+``include`` and adds the parent directory of the imported package to the C
+include path. This makes includes such as the following work from kernel
+sources:
+
+.. code-block:: c
+
+    #include "my_package/path/to/header.h"
+
+The hook only provides include paths. The headers still need to be part of the
+installed package or source distribution.
+
+Regenerating and checking
+-------------------------
+
+After changing definitions, regenerate the prebuilt kernels locally:
+
+.. code-block:: bash
+
+    xsuite-prebuild regenerate
+
+Set ``XSUITE_VERBOSE`` when checking runtime selection. With this environment
+variable set, Xsuite prints which prebuilt kernels it considers and why each
+candidate is accepted or rejected.

--- a/docs/dev_guide_xtbe_tracking_code.rst
+++ b/docs/dev_guide_xtbe_tracking_code.rst
@@ -9,7 +9,7 @@ The C API for the defined class can be inspected as follows:
 
 .. code-block:: python
 
-    source, kernels, cdefs = SRotation._XoStruct._gen_c_api()
+    source = SRotation._XoStruct._gen_c_api().source
     print(source)
 
 By printing source we can see that C methods are available to set, get and get a pointer to the fields specified in ``_xofields``:
@@ -24,7 +24,11 @@ By printing source we can see that C methods are available to set, get and get a
     /*gpufun*/ void SRotationData_set_sin_z(SRotationData/*restrict*/ obj, double value);
     /*gpufun*/ /*gpuglmem*/double* SRotationData_getp_sin_z(SRotationData/*restrict*/ obj);
 
-Note the annotations ``/*gpufun*/`` that indicates that these are device functions on GPU and ``/*gpuglmem*/`` that indicates that the annotated pointer refers to the GPU global memory space.
+The generated API source currently still uses legacy magic comments such as
+``/*gpufun*/``, ``/*gpuglmem*/`` and ``/*restrict*/``. For new handwritten C
+code, however, the preferred API is to include the Xobjects/Xtrack headers and
+use macros such as ``GPUFUN``, ``GPUGLMEM`` and ``RESTRICT``. This lets the
+compiler catch typos instead of silently ignoring misspelled magic comments.
 
 These methods can be used to write a C header file containing the tracking code for the beam element.
 The method takes two arguments, the element data in a data type called ``<ElementName>Data``, i.e. ``SRotationData`` in our example and a ``LocalParticle`` which is associated to methods to set and and get the particle coordinates.
@@ -40,13 +44,15 @@ For our example beam elements the tracking code can be written as follows:
     #ifndef XTRACK_SROTATION_H
     #define XTRACK_SROTATION_H
 
-    /*gpufun*/
+    #include "xtrack/headers/track.h"
+
+    GPUFUN
     void SRotation_track_local_particle(SRotationData el, LocalParticle* part0){
 
         double const sin_z = SRotationData_get_sin_z(el);
         double const cos_z = SRotationData_get_cos_z(el);
 
-        //start_per_particle_block (part0->part)
+        START_PER_PARTICLE_BLOCK(part0, part);
 
             double const x  = LocalParticle_get_x(part);
             double const y  = LocalParticle_get_y(part);
@@ -66,15 +72,15 @@ For our example beam elements the tracking code can be written as follows:
             LocalParticle_set_px(part, px_hat);
             LocalParticle_set_py(part, py_hat);
 
-        //end_per_particle_block
+        END_PER_PARTICLE_BLOCK;
 
     }
 
     #endif
 
-You can note in the code above the ``/*gpufun*/`` annotation specifying that the function is to be executed on the device for the GPU contexts.
+The ``GPUFUN`` macro specifies that the function is to be executed on the device for GPU contexts. It is defined in ``xobjects/headers/common.h``; for tracking code, including ``xtrack/headers/track.h`` is usually the most convenient choice because it includes ``xobjects/headers/common.h`` and also defines the particle-tracking block macros.
 
-The annotations ```//start_per_particle_block``` and ```//end_per_particle_block``` map part0 to part and introduce a loop over the particle when needed (i.e. for the CPU contexts). Parallelization over CPU cores is also applied if this is set in  the context.
+The ``START_PER_PARTICLE_BLOCK(part0, part)`` and ``END_PER_PARTICLE_BLOCK`` macros map ``part0`` to ``part`` and introduce a loop over the particles when needed (i.e. for the CPU contexts). Parallelization over CPU cores is also applied if this is set in the context.
 
 Once ready the code needs to be associated to the class. This is done with the following instruction:
 

--- a/docs/dev_guide_xtrack_beam_elements.rst
+++ b/docs/dev_guide_xtrack_beam_elements.rst
@@ -9,3 +9,4 @@ Definition of new Xtrack-compatible beam elements
     dev_guide_xtbe_tracking_code
     dev_guide_xtbe_internal_record
     dev_guide_xtbe_lost_part_codes
+    dev_guide_xtbe_prebuilt_kernels

--- a/docs/environment_api.rst
+++ b/docs/environment_api.rst
@@ -84,6 +84,10 @@ Members - short description
      - xdeps dependency manager for variables, element references, and expressions.
    * - :ref:`vars <line-api-editing-inspection-variables-and-configuration-property-vars>`
      - Variables container associated with the environment.
+   * - :ref:`xcoll <line-api-editing-inspection-variables-and-configuration-property-xcoll>`
+     - Xcoll-specific helpers associated with this environment.
+   * - :ref:`xfields <line-api-editing-inspection-variables-and-configuration-property-xfields>`
+     - Xfields-specific helpers associated with this environment.
 
 .. _line-api-reference-particle-and-particle-generation-summary:
 
@@ -169,10 +173,16 @@ Members - short description
 
    * - Member
      - Description
+   * - :ref:`from_​madx(...) <line-api-deprecated-method-from-madx>`
+     - Load a multiline from a MAD-X file.
    * - :ref:`new_​builder(...) <line-api-deprecated-method-new-builder>`
-     - Deprecated. Create a new builder.
+     - Deprecated. Create a new composer.
    * - :ref:`set_​multipolar_​errors(...) <line-api-deprecated-method-set-multipolar-errors>`
      - Deprecated: set multipolar errors for specified elements of the environment.
+   * - :ref:`varval <line-api-deprecated-property-varval>`
+     - Convenience accessor to variable values.
+   * - :ref:`vv <line-api-deprecated-property-vv>`
+     - Short alias for variable values.
 
 .. _line-api-upcoming-deprecations-summary:
 
@@ -185,19 +195,11 @@ Members - short description
    * - Member
      - Description
    * - :ref:`apply_​filling_​pattern(...) <line-api-upcoming-deprecations-method-apply-filling-pattern>`
-     - Enable only he beam-beam elements corresponding to actual encounters for the given filling pattern and the selected bunches.
+     - Deprecated alias for ``env.xfields.apply_​filling_​pattern(...)``.
    * - :ref:`configure_​beambeam_​interactions(...) <line-api-upcoming-deprecations-method-configure-beambeam-interactions>`
-     - Configure the beam-beam elements in the lines.
-   * - :ref:`copy_​element_​from(...) <line-api-upcoming-deprecations-method-copy-element-from>`
-     - Copy an element from another environment.
-   * - :ref:`from_​madx(...) <line-api-upcoming-deprecations-method-from-madx>`
-     - Load a multiline from a MAD-X file.
+     - Deprecated alias for ``env.xfields.configure_​beambeam_​interactions(...)``.
    * - :ref:`install_​beambeam_​interactions(...) <line-api-upcoming-deprecations-method-install-beambeam-interactions>`
-     - Install beam-beam elements in the lines. Elements are inserted in the lines in the appropriate positions. They are not configured and are kept inactive.
-   * - :ref:`varval <line-api-upcoming-deprecations-property-varval>`
-     - Convenience accessor to variable values.
-   * - :ref:`vv <line-api-upcoming-deprecations-property-vv>`
-     - Deprecated short alias for variable values.
+     - Deprecated alias for ``env.xfields.install_​beambeam_​interactions(...)``.
 
 
 Members - full description
@@ -310,6 +312,14 @@ Go to :ref:`Summary table <line-api-editing-inspection-variables-and-configurati
 
 .. autoproperty:: xtrack.environment.Environment.vars
 
+.. _line-api-editing-inspection-variables-and-configuration-property-xcoll:
+
+.. autoproperty:: xtrack.environment.Environment.xcoll
+
+.. _line-api-editing-inspection-variables-and-configuration-property-xfields:
+
+.. autoproperty:: xtrack.environment.Environment.xfields
+
 .. _line-api-reference-particle-and-particle-generation:
 
 Reference Particle and Particle Generation
@@ -417,6 +427,10 @@ Go to :ref:`Summary table <line-api-deprecated-summary>`
 
 .. _line-api-deprecated-methods:
 
+.. _line-api-deprecated-method-from-madx:
+
+.. automethod:: xtrack.environment.Environment.from_madx
+
 .. _line-api-deprecated-method-new-builder:
 
 .. automethod:: xtrack.environment.Environment.new_builder
@@ -424,6 +438,16 @@ Go to :ref:`Summary table <line-api-deprecated-summary>`
 .. _line-api-deprecated-method-set-multipolar-errors:
 
 .. automethod:: xtrack.environment.Environment.set_multipolar_errors
+
+.. _line-api-deprecated-properties:
+
+.. _line-api-deprecated-property-varval:
+
+.. autoproperty:: xtrack.environment.Environment.varval
+
+.. _line-api-deprecated-property-vv:
+
+.. autoproperty:: xtrack.environment.Environment.vv
 
 .. _line-api-upcoming-deprecations:
 
@@ -442,25 +466,7 @@ Go to :ref:`Summary table <line-api-upcoming-deprecations-summary>`
 
 .. automethod:: xtrack.environment.Environment.configure_beambeam_interactions
 
-.. _line-api-upcoming-deprecations-method-copy-element-from:
-
-.. automethod:: xtrack.environment.Environment.copy_element_from
-
-.. _line-api-upcoming-deprecations-method-from-madx:
-
-.. automethod:: xtrack.environment.Environment.from_madx
-
 .. _line-api-upcoming-deprecations-method-install-beambeam-interactions:
 
 .. automethod:: xtrack.environment.Environment.install_beambeam_interactions
-
-.. _line-api-upcoming-deprecations-properties:
-
-.. _line-api-upcoming-deprecations-property-varval:
-
-.. autoproperty:: xtrack.environment.Environment.varval
-
-.. _line-api-upcoming-deprecations-property-vv:
-
-.. autoproperty:: xtrack.environment.Environment.vv
 

--- a/docs/line_api.rst
+++ b/docs/line_api.rst
@@ -120,10 +120,6 @@ Members - short description
      - Get expression associated to a variable
    * - :ref:`get_​length(...) <line-api-inspection-variables-and-configuration-method-get-length>`
      - Get total length of the line
-   * - :ref:`get_​s_​elements(...) <line-api-inspection-variables-and-configuration-method-get-s-elements>`
-     - Get s position for all elements
-   * - :ref:`get_​s_​position(...) <line-api-inspection-variables-and-configuration-method-get-s-position>`
-     - Get s position for given elements
    * - :ref:`get_​strengths(...) <line-api-inspection-variables-and-configuration-method-get-strengths>`
      - Return integrated magnet strengths as a table.
    * - :ref:`get_​table(...) <line-api-inspection-variables-and-configuration-method-get-table>`
@@ -152,8 +148,6 @@ Members - short description
      - xdeps dependency manager for variables, element references, and expressions.
    * - :ref:`vars <line-api-inspection-variables-and-configuration-property-vars>`
      - Variables container associated with the line environment.
-   * - :ref:`varval <line-api-inspection-variables-and-configuration-property-varval>`
-     - Convenience accessor to variable values.
 
 .. _line-api-reference-particle-and-particle-generation-summary:
 
@@ -182,12 +176,12 @@ Members - short description
 
    * - Member
      - Description
-   * - :ref:`compute_​R_​matrix(...) <line-api-tracking-and-analysis-method-compute-r-matrix>`
-     - Compute the one turn matrix using finite differences.
-   * - :ref:`compute_​T_​matrix(...) <line-api-tracking-and-analysis-method-compute-t-matrix>`
-     - Compute the second order tensor of the beamline.
    * - :ref:`find_​closed_​orbit(...) <line-api-tracking-and-analysis-method-find-closed-orbit>`
      - Find the closed orbit of the beamline.
+   * - :ref:`get_​R_​matrix(...) <line-api-tracking-and-analysis-method-get-r-matrix>`
+     - Compute the one turn matrix using finite differences.
+   * - :ref:`get_​T_​matrix(...) <line-api-tracking-and-analysis-method-get-t-matrix>`
+     - Compute the second order tensor of the beamline.
    * - :ref:`get_​amplitude_​detuning_​coefficients(...) <line-api-tracking-and-analysis-method-get-amplitude-detuning-coefficients>`
      - Compute the amplitude detuning coefficients (det_​xx = dQx / dJx, det_​yy = dQy / dJy, det_​xy = dQx / dJy, det_​yx = dQy / dJx) using tracking.
    * - :ref:`get_​footprint(...) <line-api-tracking-and-analysis-method-get-footprint>`
@@ -295,10 +289,8 @@ Members - short description
      - Configure radiation within the line.
    * - :ref:`configure_​spin(...) <line-api-radiation-spin-and-intra-beam-scattering-method-configure-spin>`
      - Configure the spin model for the line.
-   * - :ref:`collimators <line-api-radiation-spin-and-intra-beam-scattering-property-collimators>`
-     - Interface to Xcoll collimator tools for this line.
-   * - :ref:`scattering <line-api-radiation-spin-and-intra-beam-scattering-property-scattering>`
-     - Interface to Xcoll scattering tools for this line.
+   * - :ref:`xcoll <line-api-radiation-spin-and-intra-beam-scattering-property-xcoll>`
+     - Xcoll-specific helpers associated with this line.
 
 .. _line-api-energy-longitudinal-state-summary:
 
@@ -434,9 +426,9 @@ Members - short description
    * - :ref:`regen_​madng_​model(...) <line-api-mad-ng-integration-method-regen-madng-model>`
      - Regenerate the MAD-NG model associated with this line.
 
-.. _line-api-deprecated-methods-summary:
+.. _line-api-deprecated-summary:
 
-.. list-table:: :ref:`Deprecated Methods <line-api-deprecated-methods>`
+.. list-table:: :ref:`Deprecated <line-api-deprecated>`
    :class: line-api-summary-table
    :header-rows: 1
    :width: 100%
@@ -444,16 +436,34 @@ Members - short description
 
    * - Member
      - Description
-   * - :ref:`append_​element(...) <line-api-deprecated-methods-method-append-element>`
+   * - :ref:`append_​element(...) <line-api-deprecated-method-append-element>`
      - Append element to the end of the lattice
-   * - :ref:`compute_​one_​turn_​matrix_​finite_​differences(...) <line-api-deprecated-methods-method-compute-one-turn-matrix-finite-differences>`
+   * - :ref:`compute_​R_​matrix(...) <line-api-deprecated-method-compute-r-matrix>`
+     - Compute the one turn matrix using finite differences.
+   * - :ref:`compute_​T_​matrix(...) <line-api-deprecated-method-compute-t-matrix>`
+     - Compute the second order tensor of the beamline.
+   * - :ref:`compute_​one_​turn_​matrix_​finite_​differences(...) <line-api-deprecated-method-compute-one-turn-matrix-finite-differences>`
      - Deprecated. Compute the one turn matrix using finite differences.
-   * - :ref:`from_​sixinput(...) <line-api-deprecated-methods-method-from-sixinput>`
+   * - :ref:`from_​sixinput(...) <line-api-deprecated-method-from-sixinput>`
      - ``Line.from_​sixinput`` has been removed in favour of ``sixinput.generate_​xtrack_​line()``.
-   * - :ref:`insert_​element(...) <line-api-deprecated-methods-method-insert-element>`
+   * - :ref:`get_​elements_​of_​type(...) <line-api-deprecated-method-get-elements-of-type>`
+     - Get all elements of given type(s)
+   * - :ref:`get_​s_​elements(...) <line-api-deprecated-method-get-s-elements>`
+     - Get s position for all elements
+   * - :ref:`get_​s_​position(...) <line-api-deprecated-method-get-s-position>`
+     - Get s position for given elements
+   * - :ref:`insert_​element(...) <line-api-deprecated-method-insert-element>`
      - Insert an element in the line.
-   * - :ref:`unfreeze(...) <line-api-deprecated-methods-method-unfreeze>`
+   * - :ref:`to_​pandas(...) <line-api-deprecated-method-to-pandas>`
+     - Return a pandas DataFrame with the elements of the line.
+   * - :ref:`unfreeze(...) <line-api-deprecated-method-unfreeze>`
      - Use :meth:`Line.discard_​tracker` instead.
+   * - :ref:`builder <line-api-deprecated-property-builder>`
+     - Deprecated alias for ``line.composer``.
+   * - :ref:`varval <line-api-deprecated-property-varval>`
+     - Convenience accessor to variable values.
+   * - :ref:`vv <line-api-deprecated-property-vv>`
+     - Short alias for variable values.
 
 .. _line-api-upcoming-deprecations-summary:
 
@@ -467,26 +477,20 @@ Members - short description
      - Description
    * - :ref:`check_​aperture(...) <line-api-upcoming-deprecations-method-check-aperture>`
      - Check that all active elements have an associated aperture.
-   * - :ref:`copy_​element_​from(...) <line-api-upcoming-deprecations-method-copy-element-from>`
-     - Deprecated wrapper for ``line.env.copy_​element_​from(...)``.
    * - :ref:`extend(...) <line-api-upcoming-deprecations-method-extend>`
-     - Append elements from another line to this line.
+     - Append existing element names to this line.
    * - :ref:`filter_​elements(...) <line-api-upcoming-deprecations-method-filter-elements>`
      - Return a new line with only the elements satisfying a given condition. Other elements are replaced with Drifts.
    * - :ref:`freeze_​vars(...) <line-api-upcoming-deprecations-method-freeze-vars>`
      - Freeze variables in tracked Particles objects.
    * - :ref:`get_​aperture_​table(...) <line-api-upcoming-deprecations-method-get-aperture-table>`
      - Return a table with the horizontal and vertical aperture estimated at all elements of the line. The aperture is estimated by tracking a particle through the line and measuring the maximum and minumum horizontal and vertical position at which particles survive. For elements at which no lost particles are detected, the aperture is estimated by interpolating the values of the neighbouring elements.
-   * - :ref:`get_​elements_​of_​type(...) <line-api-upcoming-deprecations-method-get-elements-of-type>`
-     - Get all elements of given type(s)
-   * - :ref:`to_​pandas(...) <line-api-upcoming-deprecations-method-to-pandas>`
-     - Return a pandas DataFrame with the elements of the line.
    * - :ref:`unfreeze_​vars(...) <line-api-upcoming-deprecations-method-unfreeze-vars>`
      - Unfreeze variables in tracked Particles objects.
-   * - :ref:`builder <line-api-upcoming-deprecations-property-builder>`
-     - Deprecated alias for ``line.composer``.
-   * - :ref:`vv <line-api-upcoming-deprecations-property-vv>`
-     - Deprecated short alias for variable values.
+   * - :ref:`collimators <line-api-upcoming-deprecations-property-collimators>`
+     - Deprecated alias for ``line.xcoll.collimators``.
+   * - :ref:`scattering <line-api-upcoming-deprecations-property-scattering>`
+     - Deprecated alias for ``line.xcoll.scattering``.
 
 
 Members - full description
@@ -647,14 +651,6 @@ Go to :ref:`Summary table <line-api-inspection-variables-and-configuration-summa
 
 .. automethod:: xtrack.line.Line.get_length
 
-.. _line-api-inspection-variables-and-configuration-method-get-s-elements:
-
-.. automethod:: xtrack.line.Line.get_s_elements
-
-.. _line-api-inspection-variables-and-configuration-method-get-s-position:
-
-.. automethod:: xtrack.line.Line.get_s_position
-
 .. _line-api-inspection-variables-and-configuration-method-get-strengths:
 
 .. automethod:: xtrack.line.Line.get_strengths
@@ -713,10 +709,6 @@ Go to :ref:`Summary table <line-api-inspection-variables-and-configuration-summa
 
 .. autoproperty:: xtrack.line.Line.vars
 
-.. _line-api-inspection-variables-and-configuration-property-varval:
-
-.. autoproperty:: xtrack.line.Line.varval
-
 .. _line-api-reference-particle-and-particle-generation:
 
 Reference Particle and Particle Generation
@@ -749,17 +741,17 @@ Go to :ref:`Summary table <line-api-tracking-and-analysis-summary>`
 
 .. _line-api-tracking-and-analysis-methods:
 
-.. _line-api-tracking-and-analysis-method-compute-r-matrix:
-
-.. automethod:: xtrack.line.Line.compute_R_matrix
-
-.. _line-api-tracking-and-analysis-method-compute-t-matrix:
-
-.. automethod:: xtrack.line.Line.compute_T_matrix
-
 .. _line-api-tracking-and-analysis-method-find-closed-orbit:
 
 .. automethod:: xtrack.line.Line.find_closed_orbit
+
+.. _line-api-tracking-and-analysis-method-get-r-matrix:
+
+.. automethod:: xtrack.line.Line.get_R_matrix
+
+.. _line-api-tracking-and-analysis-method-get-t-matrix:
+
+.. automethod:: xtrack.line.Line.get_T_matrix
 
 .. _line-api-tracking-and-analysis-method-get-amplitude-detuning-coefficients:
 
@@ -942,13 +934,9 @@ Go to :ref:`Summary table <line-api-radiation-spin-and-intra-beam-scattering-sum
 
 .. _line-api-radiation-spin-and-intra-beam-scattering-properties:
 
-.. _line-api-radiation-spin-and-intra-beam-scattering-property-collimators:
+.. _line-api-radiation-spin-and-intra-beam-scattering-property-xcoll:
 
-.. autoproperty:: xtrack.line.Line.collimators
-
-.. _line-api-radiation-spin-and-intra-beam-scattering-property-scattering:
-
-.. autoproperty:: xtrack.line.Line.scattering
+.. autoproperty:: xtrack.line.Line.xcoll
 
 .. _line-api-energy-longitudinal-state:
 
@@ -1142,34 +1130,72 @@ Go to :ref:`Summary table <line-api-mad-ng-integration-summary>`
 
 .. automethod:: xtrack.line.Line.regen_madng_model
 
+.. _line-api-deprecated:
+
+Deprecated
+~~~~~~~~~~
+
+Go to :ref:`Summary table <line-api-deprecated-summary>`
+
 .. _line-api-deprecated-methods:
 
-Deprecated Methods
-~~~~~~~~~~~~~~~~~~
-
-Go to :ref:`Summary table <line-api-deprecated-methods-summary>`
-
-.. _line-api-deprecated-methods-methods:
-
-.. _line-api-deprecated-methods-method-append-element:
+.. _line-api-deprecated-method-append-element:
 
 .. automethod:: xtrack.line.Line.append_element
 
-.. _line-api-deprecated-methods-method-compute-one-turn-matrix-finite-differences:
+.. _line-api-deprecated-method-compute-r-matrix:
+
+.. automethod:: xtrack.line.Line.compute_R_matrix
+
+.. _line-api-deprecated-method-compute-t-matrix:
+
+.. automethod:: xtrack.line.Line.compute_T_matrix
+
+.. _line-api-deprecated-method-compute-one-turn-matrix-finite-differences:
 
 .. automethod:: xtrack.line.Line.compute_one_turn_matrix_finite_differences
 
-.. _line-api-deprecated-methods-method-from-sixinput:
+.. _line-api-deprecated-method-from-sixinput:
 
 .. automethod:: xtrack.line.Line.from_sixinput
 
-.. _line-api-deprecated-methods-method-insert-element:
+.. _line-api-deprecated-method-get-elements-of-type:
+
+.. automethod:: xtrack.line.Line.get_elements_of_type
+
+.. _line-api-deprecated-method-get-s-elements:
+
+.. automethod:: xtrack.line.Line.get_s_elements
+
+.. _line-api-deprecated-method-get-s-position:
+
+.. automethod:: xtrack.line.Line.get_s_position
+
+.. _line-api-deprecated-method-insert-element:
 
 .. automethod:: xtrack.line.Line.insert_element
 
-.. _line-api-deprecated-methods-method-unfreeze:
+.. _line-api-deprecated-method-to-pandas:
+
+.. automethod:: xtrack.line.Line.to_pandas
+
+.. _line-api-deprecated-method-unfreeze:
 
 .. automethod:: xtrack.line.Line.unfreeze
+
+.. _line-api-deprecated-properties:
+
+.. _line-api-deprecated-property-builder:
+
+.. autoproperty:: xtrack.line.Line.builder
+
+.. _line-api-deprecated-property-varval:
+
+.. autoproperty:: xtrack.line.Line.varval
+
+.. _line-api-deprecated-property-vv:
+
+.. autoproperty:: xtrack.line.Line.vv
 
 .. _line-api-upcoming-deprecations:
 
@@ -1183,10 +1209,6 @@ Go to :ref:`Summary table <line-api-upcoming-deprecations-summary>`
 .. _line-api-upcoming-deprecations-method-check-aperture:
 
 .. automethod:: xtrack.line.Line.check_aperture
-
-.. _line-api-upcoming-deprecations-method-copy-element-from:
-
-.. automethod:: xtrack.line.Line.copy_element_from
 
 .. _line-api-upcoming-deprecations-method-extend:
 
@@ -1204,25 +1226,17 @@ Go to :ref:`Summary table <line-api-upcoming-deprecations-summary>`
 
 .. automethod:: xtrack.line.Line.get_aperture_table
 
-.. _line-api-upcoming-deprecations-method-get-elements-of-type:
-
-.. automethod:: xtrack.line.Line.get_elements_of_type
-
-.. _line-api-upcoming-deprecations-method-to-pandas:
-
-.. automethod:: xtrack.line.Line.to_pandas
-
 .. _line-api-upcoming-deprecations-method-unfreeze-vars:
 
 .. automethod:: xtrack.line.Line.unfreeze_vars
 
 .. _line-api-upcoming-deprecations-properties:
 
-.. _line-api-upcoming-deprecations-property-builder:
+.. _line-api-upcoming-deprecations-property-collimators:
 
-.. autoproperty:: xtrack.line.Line.builder
+.. autoproperty:: xtrack.line.Line.collimators
 
-.. _line-api-upcoming-deprecations-property-vv:
+.. _line-api-upcoming-deprecations-property-scattering:
 
-.. autoproperty:: xtrack.line.Line.vv
+.. autoproperty:: xtrack.line.Line.scattering
 

--- a/docs/xobjexample.rst
+++ b/docs/xobjexample.rst
@@ -121,6 +121,13 @@ which provides the following set of C functions:
     /*gpufun*/ void DataStructure_set_s(DataStructure/*restrict*/ obj, double value);
     /*gpufun*/ /*gpuglmem*/double* DataStructure_getp_s(DataStructure/*restrict*/ obj);
 
+The generated C declarations currently still use legacy magic comments such as
+``/*gpufun*/``, ``/*gpuglmem*/`` and ``/*restrict*/``. For new handwritten C
+code, however, include ``xobjects/headers/common.h`` and use macros such as
+``GPUFUN``, ``GPUKERN``, ``GPUGLMEM``, ``RESTRICT`` and ``VECTORIZE_OVER``.
+With macros, typos are caught by the compiler instead of being silently ignored
+as unknown comments.
+
 
 Writing a C kernel
 ------------------
@@ -132,21 +139,26 @@ As an example, using our example data structure, we write a C kernel function (r
 
     src = '''
 
-    /*gpukern*/
+    #include "xobjects/headers/common.h"
+
+    GPUKERN
     void myprod(DataStructure ob, int nelem){
 
-        for (int ii=0; ii<nelem; ii++){ //vectorize_over ii nelem
+        VECTORIZE_OVER(ii, nelem);
             double a_ii = DataStructure_get_a(ob, ii);
             double b_ii = DataStructure_get_b(ob, ii);
 
             double c_ii = a_ii * b_ii;
             DataStructure_set_c(ob, ii, c_ii);
-        } //end_vectorize
+        END_VECTORIZE;
 
     }
     '''
 
-Note the xobject annotation ``/*gpukern*/`` that specifies that the function is a kernel, as well as annotations ``//vectorize_over ii nelem`` and ``//end_vectorize`` which identifies the variable on which the calculation can be performed in parallel and the corresponding range (i.e. 0 <= ii < nelem).
+Note the Xobjects macros ``GPUKERN``, ``VECTORIZE_OVER`` and
+``END_VECTORIZE``. The first specifies that the function is a kernel. The
+vectorization macros identify the variable on which the calculation can be
+performed in parallel and the corresponding range (i.e. 0 <= ii < nelem).
 
 
 Compiling the kernel
@@ -248,7 +260,6 @@ If the chosen context is a ``ContextCupy`` the generated specialized source is:
         //end autovectorized
 
     }
-
 
 
 


### PR DESCRIPTION
## Description

- Document the new "way" of constructing C beam elements and kernels,
- Document the way prebuild kernels can be defined, extended, and verified,
- And autogeneration script updated deprecations documentation.
