### PR TITLE
Prebuild kernels for OpenMP

### DIFF
--- a/xsuite/cli.py
+++ b/xsuite/cli.py
@@ -7,16 +7,17 @@ from importlib.metadata import version
 
 from xsuite.prebuild_kernels import (
     clear_kernels, regenerate_kernels, XSK_PREBUILT_KERNELS_LOCATION,
+    SERIAL_CONTEXT, OPENMP_CONTEXT,
 )
 
 
 def regenerate_command(args):
     n_threads = args.threads
-    regenerate_kernels(n_threads=n_threads, context=args.context)
+    regenerate_kernels(n_threads=n_threads, context=args.kind)
 
 
 def clean_command(args):
-    clear_kernels(verbose=args.verbose, context=args.context)
+    clear_kernels(verbose=args.verbose, context=args.kind)
     print('Cleaned kernels.')
 
 
@@ -24,6 +25,24 @@ def info_command(args):
     version_str = version("xsuite")
     print(f'Xsuite version {version_str}')
     print(f'Kernels location: {XSK_PREBUILT_KERNELS_LOCATION}')
+
+
+def parse_kind_argument(value):
+    kinds = []
+    for raw_kind in value.split(','):
+        kind = raw_kind.strip()
+        if kind not in (SERIAL_CONTEXT, OPENMP_CONTEXT):
+            raise argparse.ArgumentTypeError(
+                f'unsupported kind `{kind}`; expected `serial`, `openmp`, '
+                f'or a comma-separated combination'
+            )
+        if kind not in kinds:
+            kinds.append(kind)
+
+    if not kinds:
+        raise argparse.ArgumentTypeError('at least one kind must be provided')
+
+    return tuple(kinds)
 
 
 def main():
@@ -50,10 +69,10 @@ def main():
              '(default or zero: let multiprocessing decide)',
     )
     regenerate_parser.add_argument(
-        '--context',
-        choices=('serial', 'omp'),
-        default='serial',
-        help='build serial CPU kernels or OpenMP CPU kernels',
+        '--kind',
+        type=parse_kind_argument,
+        default=(SERIAL_CONTEXT,),
+        help='build `serial`, `openmp`, or both with `serial,openmp`',
     )
     regenerate_parser.set_defaults(func=regenerate_command)
 
@@ -69,10 +88,10 @@ def main():
         action='store_true',
     )
     clean_parser.add_argument(
-        '--context',
-        choices=('serial', 'omp'),
+        '--kind',
+        type=parse_kind_argument,
         default=None,
-        help='remove only kernels for the selected CPU context',
+        help='remove only `serial`, `openmp`, or both with `serial,openmp`',
     )
     clean_parser.set_defaults(func=clean_command)
 

--- a/xsuite/cli.py
+++ b/xsuite/cli.py
@@ -12,11 +12,11 @@ from xsuite.prebuild_kernels import (
 
 def regenerate_command(args):
     n_threads = args.threads
-    regenerate_kernels(n_threads=n_threads)
+    regenerate_kernels(n_threads=n_threads, context=args.context)
 
 
 def clean_command(args):
-    clear_kernels(verbose=args.verbose)
+    clear_kernels(verbose=args.verbose, context=args.context)
     print('Cleaned kernels.')
 
 
@@ -49,6 +49,12 @@ def main():
         help='specify the number of threads for kernel generation '
              '(default or zero: let multiprocessing decide)',
     )
+    regenerate_parser.add_argument(
+        '--context',
+        choices=('serial', 'omp'),
+        default='serial',
+        help='build serial CPU kernels or OpenMP CPU kernels',
+    )
     regenerate_parser.set_defaults(func=regenerate_command)
 
     # `clean` command
@@ -61,6 +67,12 @@ def main():
         '-v', '--verbose',
         help='list the files being deleted',
         action='store_true',
+    )
+    clean_parser.add_argument(
+        '--context',
+        choices=('serial', 'omp'),
+        default=None,
+        help='remove only kernels for the selected CPU context',
     )
     clean_parser.set_defaults(func=clean_command)
 

--- a/xsuite/prebuild_kernels.py
+++ b/xsuite/prebuild_kernels.py
@@ -28,7 +28,7 @@ BEAM_ELEMENTS_INIT_DEFAULTS = XTRACK_ELEMENTS_INIT_DEFAULTS| XFIELDS_ELEMENTS_IN
                             | XCOLL_ELEMENTS_INIT_DEFAULTS
 
 SERIAL_CONTEXT = 'serial'
-OPENMP_CONTEXT = 'omp'
+OPENMP_CONTEXT = 'openmp'
 CONTEXT_SUFFIXES = {
     SERIAL_CONTEXT: '_cpu_serial',
     OPENMP_CONTEXT: '_cpu_openmp',
@@ -41,6 +41,31 @@ def _context_key_from_cli(context: Optional[str]) -> Optional[str]:
     if context not in (SERIAL_CONTEXT, OPENMP_CONTEXT):
         raise ValueError(f'Unsupported prebuild context `{context}`.')
     return context
+
+
+def _context_keys_from_cli(context) -> Optional[Tuple[str, ...]]:
+    if context is None:
+        return None
+
+    if isinstance(context, str):
+        raw_contexts = context.split(',')
+    elif hasattr(context, '__iter__'):
+        raw_contexts = context
+    else:
+        raw_contexts = [context]
+
+    context_keys = []
+    for raw_context in raw_contexts:
+        if raw_context is None:
+            continue
+        context_key = _context_key_from_cli(raw_context.strip())
+        if context_key not in context_keys:
+            context_keys.append(context_key)
+
+    if not context_keys:
+        raise ValueError('At least one prebuild context must be provided.')
+
+    return tuple(context_keys)
 
 
 def _context_key_from_runtime(context) -> Optional[str]:
@@ -277,7 +302,7 @@ def regenerate_kernels(
         kernels = [kernels]
 
     location = Path(location)
-    context_key = _context_key_from_cli(context)
+    context_keys = _context_keys_from_cli(context)
 
     # Delete existing kernels to avoid accidentally loading in existing C code
     clear_kernels(kernels=kernels, location=location, context=context)
@@ -289,11 +314,12 @@ def regenerate_kernels(
         for base_module_name, metadata in kernel_definitions:
             if kernels is not None and base_module_name not in kernels:
                 continue
-            module_name = _module_name_for_context(base_module_name, context_key)
-            kernels_to_build.append((base_module_name, module_name, metadata))
+            for context_key in context_keys:
+                module_name = _module_name_for_context(base_module_name, context_key)
+                kernels_to_build.append((base_module_name, module_name, metadata, context_key))
 
         if n_threads == 0:
-            for idx, (base_module_name, module_name, metadata) in enumerate(kernels_to_build):
+            for idx, (base_module_name, module_name, metadata, context_key) in enumerate(kernels_to_build):
                 build_single_kernel(
                     idx, len(kernels_to_build), location, metadata, module_name,
                     base_module_name, context_key,
@@ -301,7 +327,7 @@ def regenerate_kernels(
         else:
             thread_pool = get_context('spawn').Pool(processes=n_threads)
             results = []
-            for idx, (base_module_name, module_name, metadata) in enumerate(kernels_to_build):
+            for idx, (base_module_name, module_name, metadata, context_key) in enumerate(kernels_to_build):
                 args = (
                     idx, len(kernels_to_build), location, metadata, module_name,
                     base_module_name, context_key,
@@ -405,7 +431,7 @@ def clear_kernels(
         kernels = [kernels]
 
     location = Path(location)
-    context_key = _context_key_from_cli(context)
+    context_keys = _context_keys_from_cli(context)
 
     for file in location.iterdir():
         if file.name.startswith('_'):
@@ -418,7 +444,7 @@ def clear_kernels(
 
         if kernels is not None and base_module_name not in kernels:
             continue
-        if context_key is not None and file_context_key != context_key:
+        if context_keys is not None and file_context_key not in context_keys:
             continue
         file.unlink()
 

--- a/xsuite/prebuild_kernels.py
+++ b/xsuite/prebuild_kernels.py
@@ -27,11 +27,58 @@ XSK_PREBUILT_KERNELS_LOCATION = Path(xs.__file__).parent / 'lib'
 BEAM_ELEMENTS_INIT_DEFAULTS = XTRACK_ELEMENTS_INIT_DEFAULTS| XFIELDS_ELEMENTS_INIT_DEFAULTS \
                             | XCOLL_ELEMENTS_INIT_DEFAULTS
 
+SERIAL_CONTEXT = 'serial'
+OPENMP_CONTEXT = 'omp'
+CONTEXT_SUFFIXES = {
+    SERIAL_CONTEXT: '_cpu_serial',
+    OPENMP_CONTEXT: '_cpu_openmp',
+}
 
+
+def _context_key_from_cli(context: Optional[str]) -> Optional[str]:
+    if context is None:
+        return None
+    if context not in (SERIAL_CONTEXT, OPENMP_CONTEXT):
+        raise ValueError(f'Unsupported prebuild context `{context}`.')
+    return context
+
+
+def _context_key_from_runtime(context) -> Optional[str]:
+    if context is None:
+        return None
+    if not isinstance(context, xo.ContextCpu):
+        return None
+    if context.openmp_enabled:
+        return OPENMP_CONTEXT
+    return SERIAL_CONTEXT
+
+
+def _context_key_from_metadata(kernel_metadata: dict) -> str:
+    return kernel_metadata.get('context', SERIAL_CONTEXT)
+
+
+def _split_module_name(module_name: str) -> Tuple[str, str]:
+    for context_key, suffix in CONTEXT_SUFFIXES.items():
+        if module_name.endswith(suffix):
+            return module_name[:-len(suffix)], context_key
+    return module_name, SERIAL_CONTEXT
+
+
+def _module_name_for_context(base_module_name: str, context_key: str) -> str:
+    return f'{base_module_name}{CONTEXT_SUFFIXES[context_key]}'
+
+
+def _iter_kernel_metadata_files():
+    for metadata_file in sorted(XSK_PREBUILT_KERNELS_LOCATION.glob('*.json')):
+        if metadata_file.name.startswith('_'):
+            continue
+        yield metadata_file
 
 
 def save_kernel_metadata(
         module_name: str,
+        base_module_name: str,
+        context_key: str,
         config: dict,
         tracker_element_classes,
         all_classes,
@@ -41,6 +88,8 @@ def save_kernel_metadata(
     out_file = location / f'{module_name}.json'
 
     kernel_metadata = {
+        'base_module_name': base_module_name,
+        'context': context_key,
         'config': config.data,
         'tracker_element_classes': [cls._DressingClass.__name__ for cls in tracker_element_classes],
         'classes': [getattr(cls, '_DressingClass', cls).__name__ for cls in all_classes],
@@ -61,14 +110,25 @@ def enumerate_kernels(verbose=False) -> Iterator[Tuple[str, dict]]:
     xsuite. The first element of the tuple is the name of the kernel module
     and the second is a dictionary with the kernel metadata.
     """
-    for kernel_name, _ in kernel_definitions:
-        metadata_file = XSK_PREBUILT_KERNELS_LOCATION / f'{kernel_name}.json'
-
-        if not metadata_file.exists():
-            continue
+    kernel_order = {name: idx for idx, (name, _) in enumerate(kernel_definitions)}
+    candidates = []
+    for metadata_file in _iter_kernel_metadata_files():
+        module_name = metadata_file.stem
 
         with metadata_file.open('r') as fd:
             kernel_metadata = json.load(fd)
+
+        base_module_name = kernel_metadata.get('base_module_name')
+        if base_module_name is None:
+            base_module_name, _ = _split_module_name(module_name)
+            kernel_metadata['base_module_name'] = base_module_name
+
+        explicit_context = 'context' in kernel_metadata
+        context_key = _context_key_from_metadata(kernel_metadata)
+        kernel_metadata['context'] = context_key
+
+        if base_module_name not in kernel_order:
+            continue
 
         needed_versions = kernel_metadata['versions']
         have_versions = {
@@ -88,20 +148,29 @@ def enumerate_kernels(verbose=False) -> Iterator[Tuple[str, dict]]:
             version_mismatch = True
             if verbose:
                 _print(
-                    f'Version mismatch for kernel `{kernel_name}`: needs '
+                    f'Version mismatch for kernel `{module_name}`: needs '
                     f'{package}=={need}, but have {package}=={have}.'
                 )
 
         if version_mismatch:
             continue
 
-        yield metadata_file.stem, kernel_metadata
+        candidates.append((
+            kernel_order[base_module_name],
+            0 if explicit_context else 1,
+            module_name,
+            kernel_metadata,
+        ))
+
+    for _, _, module_name, kernel_metadata in sorted(candidates):
+        yield module_name, kernel_metadata
 
 
 def get_suitable_kernel(
         config: dict,
         tracker_element_classes,
         classes,
+        context=None,
         verbose=False,
 ) -> Optional[Tuple[str, list]]:
     """
@@ -124,10 +193,19 @@ def get_suitable_kernel(
         cls._DressingClass.__name__ for cls in tracker_element_classes
     ]
     requested_class_names = [getattr(cls, '_DressingClass', cls).__name__ for cls in classes]
+    requested_context = _context_key_from_runtime(context)
 
     for module_name, kernel_metadata in enumerate_kernels(verbose=verbose):
         if verbose:
             print(f"==> Considering the precompiled kernel `{module_name}`...")
+
+        kernel_context = _context_key_from_metadata(kernel_metadata)
+        if requested_context is not None and kernel_context != requested_context:
+            if verbose:
+                print(f'The kernel `{module_name}` is unsuitable. Its context '
+                      f'is `{kernel_context}`, but the requested one is '
+                      f'`{requested_context}`.')
+            continue
 
         if kernel_metadata['config'] != config:
             if verbose:
@@ -188,6 +266,7 @@ def regenerate_kernels(
         kernels=None,
         location=XSK_PREBUILT_KERNELS_LOCATION,
         n_threads=None,
+        context='serial',
 ):
     """
     Use the kernel definitions in the `kernel_definitions.py` file to
@@ -198,50 +277,71 @@ def regenerate_kernels(
         kernels = [kernels]
 
     location = Path(location)
+    context_key = _context_key_from_cli(context)
 
     # Delete existing kernels to avoid accidentally loading in existing C code
-    clear_kernels(kernels=kernels, location=location)
+    clear_kernels(kernels=kernels, location=location, context=context)
 
-    kernels_to_build = []
-    for module_name, metadata in kernel_definitions:
-        if kernels is not None and module_name not in kernels:
-            continue
-        kernels_to_build.append((module_name, metadata))
+    old_prebuilt_env = os.environ.get("XSUITE_PREBUILT_KERNELS")
+    os.environ["XSUITE_PREBUILT_KERNELS"] = "0"
+    try:
+        kernels_to_build = []
+        for base_module_name, metadata in kernel_definitions:
+            if kernels is not None and base_module_name not in kernels:
+                continue
+            module_name = _module_name_for_context(base_module_name, context_key)
+            kernels_to_build.append((base_module_name, module_name, metadata))
 
-    if n_threads == 0:
-         for idx, (module_name, metadata) in enumerate(kernels_to_build):
-            build_single_kernel(idx, len(kernels_to_build), location, metadata, module_name)
-    else:
-        thread_pool = get_context('spawn').Pool(processes=n_threads)
-        results = []
-        for idx, (module_name, metadata) in enumerate(kernels_to_build):
-            args = (idx, len(kernels_to_build), location, metadata, module_name)
-            result = thread_pool.apply_async(build_single_kernel, args=args)
-            results.append(result)
+        if n_threads == 0:
+            for idx, (base_module_name, module_name, metadata) in enumerate(kernels_to_build):
+                build_single_kernel(
+                    idx, len(kernels_to_build), location, metadata, module_name,
+                    base_module_name, context_key,
+                )
+        else:
+            thread_pool = get_context('spawn').Pool(processes=n_threads)
+            results = []
+            for idx, (base_module_name, module_name, metadata) in enumerate(kernels_to_build):
+                args = (
+                    idx, len(kernels_to_build), location, metadata, module_name,
+                    base_module_name, context_key,
+                )
+                result = thread_pool.apply_async(build_single_kernel, args=args)
+                results.append(result)
 
-        thread_pool.close()
-        thread_pool.join()
+            thread_pool.close()
+            thread_pool.join()
 
-        # Ensure no errors
-        for result in results:
-            result.get()
+            # Ensure no errors
+            for result in results:
+                result.get()
+    finally:
+        if old_prebuilt_env is None:
+            del os.environ["XSUITE_PREBUILT_KERNELS"]
+        else:
+            os.environ["XSUITE_PREBUILT_KERNELS"] = old_prebuilt_env
 
     _print(f'Built {len(kernels_to_build)} kernels.')
 
 
-def build_single_kernel(idx, total, location, metadata, module_name):
+def build_single_kernel(
+        idx, total, location, metadata, module_name, base_module_name, context_key,
+):
     _print(f'[{idx + 1}/{total}] Building `{module_name}`...')
 
     config = metadata['config']
     element_classes = metadata['classes']
     extra_classes = metadata.get('extra_classes', [])
+    build_context = xo.ContextCpu() if context_key == SERIAL_CONTEXT else xo.ContextCpu(
+        omp_num_threads='auto'
+    )
 
     with warnings.catch_warnings():
         # We still include deprecated elements in the kernels, so silence the warnings
         warnings.filterwarnings('ignore', category=FutureWarning)
 
         elements = []
-        buffer = xo.context_default.new_buffer()
+        buffer = build_context.new_buffer()
         for cls in element_classes:
             if cls.__name__ in BEAM_ELEMENTS_INIT_DEFAULTS:
                 element = cls(**BEAM_ELEMENTS_INIT_DEFAULTS[cls.__name__],
@@ -251,7 +351,12 @@ def build_single_kernel(idx, total, location, metadata, module_name):
             elements.append(element)
 
     line = xt.Line(elements=elements)
-    tracker = xt.Tracker(line=line, compile=False, _prebuilding_kernels=True)
+    tracker = xt.Tracker(
+        line=line,
+        compile=False,
+        _context=build_context,
+        _prebuilding_kernels=True,
+    )
     assert tracker.iscollective == False
     tracker.config.clear()
     tracker.config.update(config)
@@ -280,6 +385,8 @@ def build_single_kernel(idx, total, location, metadata, module_name):
 
     save_kernel_metadata(
         module_name=module_name,
+        base_module_name=base_module_name,
+        context_key=context_key,
         config=tracker.config,
         tracker_element_classes=tracker._tracker_data_base.kernel_element_classes,
         all_classes=all_classes,
@@ -287,19 +394,31 @@ def build_single_kernel(idx, total, location, metadata, module_name):
     )
 
 
-def clear_kernels(kernels=None, verbose=False, location=XSK_PREBUILT_KERNELS_LOCATION):
+def clear_kernels(
+        kernels=None,
+        verbose=False,
+        location=XSK_PREBUILT_KERNELS_LOCATION,
+        context=None,
+):
     if kernels is not None and (
             isinstance(kernels, str) or not hasattr(kernels, '__iter__')):
         kernels = [kernels]
 
     location = Path(location)
+    context_key = _context_key_from_cli(context)
 
     for file in location.iterdir():
         if file.name.startswith('_'):
             continue
         if file.suffix not in ('.c', '.so', '.json'):
             continue
-        if kernels is not None and file.stem.split('.')[0] not in kernels:
+
+        module_name = file.stem.split('.')[0]
+        base_module_name, file_context_key = _split_module_name(module_name)
+
+        if kernels is not None and base_module_name not in kernels:
+            continue
+        if context_key is not None and file_context_key != context_key:
             continue
         file.unlink()
 


### PR DESCRIPTION
Replaces #851

## Description

Enable optional prebuilding of OpenMP kernels with `xsuite-prebuild r --kind openmp`.

Requires: xsuite/xobjects#174 and xsuite/xtrack#794.

Closes #687.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
