### PR TITLE
Limit repos in the no-compile workflow, build kernels after other pkgs present

### DIFF
--- a/.github/scripts/install_branches.sh
+++ b/.github/scripts/install_branches.sh
@@ -24,8 +24,6 @@ if [ "${install_mpi:-false}" == "true" ]; then
   pip install mpi4py
 fi
 
-pip install --no-deps -v -e "${xsuite_prefix}/xsuite"
-
 # Clone the repos and install them in the correct branch
 for project in "${repos[@]}"; do
   branch_varname="${project//-/_}_branch"
@@ -43,3 +41,5 @@ for project in "${repos[@]}"; do
 
     pip install -e "${xsuite_prefix}/${project}[tests]"
 done
+
+pip install --no-deps -v -e "${xsuite_prefix}/xsuite"

--- a/.github/workflows/cron_test_sh_cpu_no_compile.yaml
+++ b/.github/workflows/cron_test_sh_cpu_no_compile.yaml
@@ -16,6 +16,6 @@ jobs:
     with:
       test_contexts: 'ContextCpu'
       platform: 'alma-cpu-3'
-      suites: '["xobjects", "xdeps", "xpart", "xtrack", "xfields", "xcoll", "xwakes"]'
+      suites: '["xpart", "xtrack", "xfields", "xcoll", "xwakes"]'
       forbid_compile: true
       precompile_kernels: true


### PR DESCRIPTION
## Description

- Limit the repos that are tested in the `FORBID_COMPILE` workflow
- Build kernels only after all the required dependencies are installed