### PR TITLE
Add Xcoll non-tracking elements.

### DIFF
--- a/xsuite/kernel_definitions.py
+++ b/xsuite/kernel_definitions.py
@@ -6,7 +6,8 @@ import logging
 
 from xtrack.prebuilt_kernel_definitions import (ONLY_XTRACK_ELEMENTS,
                                     NO_SYNRAD_ELEMENTS, NON_TRACKING_ELEMENTS)
-from xcoll.prebuilt_kernel_definitions import DEFAULT_XCOLL_ELEMENTS, EXTRA_XCOLL_ELEMENTS
+from xcoll.prebuilt_kernel_definitions import (DEFAULT_XCOLL_ELEMENTS,
+                                    EXTRA_XCOLL_ELEMENTS, XCOLL_NON_TRACKING_ELEMENTS)
 from xfields.prebuilt_kernel_definitions import DEFAULT_XFIELDS_ELEMENTS
 from xfields.prebuilt_kernel_definitions import NON_TRACKING_ELEMENTS as XFIELDS_NON_TRACKING_ELEMENTS
 
@@ -29,7 +30,9 @@ kernel_definitions = [
     ('non_tracking_kernels', {
         'config': {},
         'classes': [],
-        'extra_classes': [xt.Particles] + NON_TRACKING_ELEMENTS + XFIELDS_NON_TRACKING_ELEMENTS,
+        'extra_classes': [xt.Particles] + NON_TRACKING_ELEMENTS \
+                         + XFIELDS_NON_TRACKING_ELEMENTS \
+                         + XCOLL_NON_TRACKING_ELEMENTS,
     }),
     ('default_no_config', {
         'config': {},


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Add non-tracking elements from Xcoll to prebuild kernels; this allows for FLUKA and Geant4 elements to be included.

On the Xcoll side, it is checked at import if FLUKA is available and the connection compiled; if yes, the FLUKA elements are added to `XCOLL_NON_TRACKING_ELEMENTS`; the same is done for Geant4.
In practice, this means that the user will have to manually rebuild the kernels after compiling the FLUKA/Geant4 environments.

This branch can be merged; all necessary changes in Xcoll have already been released.


## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
