### PR TITLE
When testing prebuilt make sure to build correct versions

### DIFF
--- a/.github/scripts/install_branches.sh
+++ b/.github/scripts/install_branches.sh
@@ -58,5 +58,5 @@ for project in "${repos[@]}"; do
 done
 
 echo "::group::Installing xsuite"
-pip install --no-deps -v -e "${xsuite_prefix}/xsuite"
+pip install --no-build-isolation --no-deps -v -e "${xsuite_prefix}/xsuite"
 echo "::endgroup::"

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,10 @@ class CustomBuildExtCommand(build_ext):
         else:
             n_threads = None
 
+        # Ensure source-tree distribution metadata exists and reflects
+        # the version already resolved by setuptools/setuptools-scm.
+        self.run_command("egg_info")
+
         # Modern setuptools/pip don't guarantee that building happens in the
         # package directory. As we need the kernel generation code here, we
         # add the package directory to the path to be able to import it.


### PR DESCRIPTION
## Description

CI jobs that select `prebuild_kernels` currently build kernels against the package versions declared in `pyproject.toml`, rather than the package branches installed by the job. This is invisible on nightly builds, but causes subtle failures when testing branches together.

The root cause is that `regenerate_kernels` is used both:

* at build time (during `pip install`), and
* at runtime (via `xsuite-prebuild`).

At build time, importing `xsuite.prebuild_kernels` imports `xsuite`, which resolves `__version__` from distribution metadata. During an editable build that metadata is not guaranteed to exist yet, so the import can fail.

This PR makes two changes:

1. **Disable build isolation for the `xsuite` install in CI.**

   Build isolation creates a temporary environment containing the packages listed in `[build-system].requires`. Kernel generation would therefore use those released dependencies instead of the editable packages already installed by the CI job. Using `--no-build-isolation` ensures kernels are generated against the branches under test.

2. **Run `egg_info` before importing `xsuite.prebuild_kernels`.**

   This generates source-tree distribution metadata, allowing `importlib.metadata.version("xsuite")` to resolve the package version during the build.

The only requirement of this approach is that the non-isolated environment satisfies `[build-system].requires` (in particular, a sufficiently recent `setuptools` and `setuptools-scm`).