### PR TITLE
Release Prerequisites 0.55.0

### DIFF
--- a/.github/scripts/install_branches.sh
+++ b/.github/scripts/install_branches.sh
@@ -58,5 +58,5 @@ for project in "${repos[@]}"; do
 done
 
 echo "::group::Installing xsuite"
-pip install --no-deps -v -e "${xsuite_prefix}/xsuite"
+pip install --no-build-isolation --no-deps -v -e "${xsuite_prefix}/xsuite"
 echo "::endgroup::"

--- a/docs/dev_guide_xtbe_prebuilt_kernels.rst
+++ b/docs/dev_guide_xtbe_prebuilt_kernels.rst
@@ -10,7 +10,7 @@ kernel shared objects contain the required code.
 The definitions live in two places:
 
 * package-local ``prebuilt_kernel_definitions`` modules, which expose element
-  classes and optional constructor defaults;
+  classes;
 * ``xsuite/kernel_definitions.py``, which combines those package-local lists
   into the actual prebuilt kernel configurations built by ``xsuite-prebuild``.
 
@@ -29,29 +29,11 @@ exports:
         NO_SYNRAD_ELEMENTS,
         NON_TRACKING_ELEMENTS,
     )
-    from .element_inits import XTRACK_ELEMENTS_INIT_DEFAULTS
-
 The element-type module contains the classes to make available in prebuilt
 kernels. Tracking elements go in the lists used as ``classes`` in
 ``xsuite/kernel_definitions.py``. Helper structures and elements that are not
 part of the line, but whose APIs or extra kernels need to be present, go in
 ``extra_classes`` through a package-local list such as ``NON_TRACKING_ELEMENTS``.
-
-Some classes cannot be instantiated with an empty constructor. For those,
-provide minimal build-time arguments in the package-local
-``*_ELEMENTS_INIT_DEFAULTS`` dictionary:
-
-.. code-block:: python
-
-    XTRACK_ELEMENTS_INIT_DEFAULTS = {
-        'LimitPolygon': {
-            'x_vertices': np.array([0, 1, 1, 0]),
-            'y_vertices': np.array([0, 0, 1, 1]),
-        },
-    }
-
-These objects are only used to build representative trackers for kernel
-generation. Keep the defaults as small and inert as possible.
 
 Adding a class to Xsuite kernels
 --------------------------------
@@ -74,8 +56,9 @@ Each entry has this shape:
     }),
 
 ``classes``
-    Beam elements that are placed in the temporary ``xt.Line`` used to build the
-    tracker kernel.
+    Beam element classes compiled into the tracker kernel switch. Xsuite
+    classifies these with ``issubclass(..., xt.BeamElement)``; non-beam-element
+    entries are compiled as extra classes.
 
 ``extra_classes``
     Xobjects classes that are not line elements for this configuration, but

--- a/docs/dev_guide_xtbe_prebuilt_kernels.rst
+++ b/docs/dev_guide_xtbe_prebuilt_kernels.rst
@@ -56,9 +56,7 @@ Each entry has this shape:
     }),
 
 ``classes``
-    Beam element classes compiled into the tracker kernel switch. Xsuite
-    classifies these with ``issubclass(..., xt.BeamElement)``; non-beam-element
-    entries are compiled as extra classes.
+    Beam element classes compiled into the tracker kernel switch.
 
 ``extra_classes``
     Xobjects classes that are not line elements for this configuration, but

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,10 @@ class CustomBuildExtCommand(build_ext):
         else:
             n_threads = None
 
+        # Ensure source-tree distribution metadata exists and reflects
+        # the version already resolved by setuptools/setuptools-scm.
+        self.run_command("egg_info")
+
         # Modern setuptools/pip don't guarantee that building happens in the
         # package directory. As we need the kernel generation code here, we
         # add the package directory to the path to be able to import it.

--- a/xsuite/__init__.py
+++ b/xsuite/__init__.py
@@ -4,7 +4,18 @@
 # ########################################### #
 
 from importlib.metadata import version
-__version__ = version(__name__)
+
+# Enable lazy loading of the version: during package build Xsuite might not be
+# installed, leading to a PackageNotFind error when `version` is called. This
+# allows us to import Xsuite even if it's not installed. As long as `__version__`
+# is not needed, there will be no errors.
+def __getattr__(name: str):
+    if name == "__version__":
+        value = version("xsuite")
+        globals()["__version__"] = value  # Cache after first lookup
+        return value
+
+    raise AttributeError(f"Module {__name__!r} has no attribute {name!r}")
 
 from .prebuild_kernels import (
     PrebuiltKernelNotFoundError,

--- a/xsuite/prebuild_kernels.py
+++ b/xsuite/prebuild_kernels.py
@@ -292,7 +292,7 @@ def build_single_kernel(
     _print(f'[{idx + 1}/{total}] Building `{module_name}`...')
 
     config = metadata['config']
-    element_classes = metadata['classes']
+    tracker_element_classes = metadata['classes']
     extra_classes = metadata.get('extra_classes', [])
     build_context = xo.ContextCpu() if context_key == SERIAL_CONTEXT else xo.ContextCpu(
         omp_num_threads='auto'
@@ -302,9 +302,6 @@ def build_single_kernel(
         # We still include deprecated elements in the kernels, so silence the warnings
         warnings.filterwarnings('ignore', category=FutureWarning)
 
-        tracker_element_classes, non_tracker_classes = _split_tracker_classes(
-            element_classes)
-
         tracker_config = xt.tracker.TrackerConfig()
         tracker_config.update(config)
 
@@ -312,7 +309,7 @@ def build_single_kernel(
             context=build_context,
             config=tracker_config,
             tracker_element_classes=tracker_element_classes,
-            extra_classes=[*extra_classes, *non_tracker_classes],
+            extra_classes=extra_classes,
             module_name=module_name,
             containing_dir=location,
             compile='force',
@@ -327,20 +324,6 @@ def build_single_kernel(
         all_classes=kernel_info['all_classes'],
         location=location,
     )
-
-
-def _split_tracker_classes(classes):
-    tracker_element_classes = []
-    extra_classes = []
-
-    for cls in classes:
-        dressing_class = getattr(cls, '_DressingClass', cls)
-        if issubclass(dressing_class, xt.BeamElement):
-            tracker_element_classes.append(cls)
-        else:
-            extra_classes.append(cls)
-
-    return tracker_element_classes, extra_classes
 
 
 def clear_kernels(

--- a/xsuite/prebuild_kernels.py
+++ b/xsuite/prebuild_kernels.py
@@ -15,18 +15,12 @@ import xcoll as xc
 import xfields as xf
 import xobjects as xo
 import xtrack as xt
-from xcoll.prebuilt_kernel_definitions import XCOLL_ELEMENTS_INIT_DEFAULTS
-from xfields.prebuilt_kernel_definitions import XFIELDS_ELEMENTS_INIT_DEFAULTS
 from xtrack.general import _print
-from xtrack.prebuilt_kernel_definitions import XTRACK_ELEMENTS_INIT_DEFAULTS
 
 import xsuite as xs
 from xsuite.kernel_definitions import kernel_definitions, NAME_CLASS_MAP
 
 XSK_PREBUILT_KERNELS_LOCATION = Path(xs.__file__).parent / 'lib'
-
-BEAM_ELEMENTS_INIT_DEFAULTS = XTRACK_ELEMENTS_INIT_DEFAULTS| XFIELDS_ELEMENTS_INIT_DEFAULTS \
-                            | XCOLL_ELEMENTS_INIT_DEFAULTS
 
 SERIAL_CONTEXT = 'serial'
 OPENMP_CONTEXT = 'openmp'
@@ -308,58 +302,45 @@ def build_single_kernel(
         # We still include deprecated elements in the kernels, so silence the warnings
         warnings.filterwarnings('ignore', category=FutureWarning)
 
-        elements = []
-        buffer = build_context.new_buffer()
-        for cls in element_classes:
-            if cls.__name__ in BEAM_ELEMENTS_INIT_DEFAULTS:
-                element = cls(**BEAM_ELEMENTS_INIT_DEFAULTS[cls.__name__],
-                              _buffer=buffer)
-            else:
-                element = cls(_buffer=buffer)
-            elements.append(element)
+        tracker_element_classes, non_tracker_classes = _split_tracker_classes(
+            element_classes)
 
-    line = xt.Line(elements=elements)
-    tracker = xt.Tracker(
-        line=line,
-        compile=False,
-        _context=build_context,
-        _prebuilding_kernels=True,
-    )
-    assert tracker.iscollective == False
-    tracker.config.clear()
-    tracker.config.update(config)
-    tracker_classes = tracker._tracker_data_base.kernel_element_classes
-    expected_classes = [getattr(el, '_XoStruct', el) for el in element_classes]
-    all_extra_classes = extra_classes + [ee for ee in expected_classes if ee not in tracker_classes]
+        tracker_config = xt.tracker.TrackerConfig()
+        tracker_config.update(config)
 
-    # Get all kernels in the elements
-    extra_kernels = {}
-    extra_xostructs = [getattr(el, '_XoStruct', el) for el in all_extra_classes]
-
-    all_classes = tracker._tracker_data_base.kernel_element_classes + extra_xostructs
-
-    assert len(set(all_classes)) == len(all_classes), 'Duplicate classes in kernel definition.'
-
-    for el in all_classes:
-        extra_kernels.update(el._kernels)
-
-    tracker._build_kernel(
-        module_name=module_name,
-        containing_dir=location,
-        compile='force',
-        extra_classes=extra_xostructs,
-        extra_kernels=extra_kernels,
-    )
+        kernel_info = xt.Tracker._build_kernel_from_classes(
+            context=build_context,
+            config=tracker_config,
+            tracker_element_classes=tracker_element_classes,
+            extra_classes=[*extra_classes, *non_tracker_classes],
+            module_name=module_name,
+            containing_dir=location,
+            compile='force',
+        )
 
     save_kernel_metadata(
         module_name=module_name,
         base_module_name=base_module_name,
         context_key=context_key,
-        config=tracker.config,
-        tracker_element_classes=tracker._tracker_data_base.kernel_element_classes,
-        all_classes=all_classes,
+        config=tracker_config,
+        tracker_element_classes=kernel_info['tracker_element_classes'],
+        all_classes=kernel_info['all_classes'],
         location=location,
     )
+
+
+def _split_tracker_classes(classes):
+    tracker_element_classes = []
+    extra_classes = []
+
+    for cls in classes:
+        dressing_class = getattr(cls, '_DressingClass', cls)
+        if issubclass(dressing_class, xt.BeamElement):
+            tracker_element_classes.append(cls)
+        else:
+            extra_classes.append(cls)
+
+    return tracker_element_classes, extra_classes
 
 
 def clear_kernels(

--- a/xsuite/prebuild_kernels.py
+++ b/xsuite/prebuild_kernels.py
@@ -305,10 +305,14 @@ def build_single_kernel(
         tracker_config = xt.tracker.TrackerConfig()
         tracker_config.update(config)
 
-        kernel_info = xt.Tracker._build_kernel_from_classes(
+        kernel_info = xt.Tracker._compile_kernel_from_classes(
             context=build_context,
             config=tracker_config,
-            tracker_element_classes=tracker_element_classes,
+            tracker_element_classes=[
+                *tracker_element_classes,
+                xt.ParticlesMonitor,
+                xt.MultiElementMonitor,
+            ],
             extra_classes=extra_classes,
             module_name=module_name,
             containing_dir=location,


### PR DESCRIPTION
**Changes:**

- Reduce precompiled kernel compilation time through removal of redundant compilations: do not assemble a dummy line in order to pre-build trackers #880.
- Fix a bug where wrong prebuilt kernels were build in CI when custom branches were specified: install the `xsuite` package with `--no-build-isolation` and make changes to `setup.py` to enable this path #879.