### PR TITLE
Add prebuilt kernels for TPSA

### DIFF
--- a/.github/scripts/install_branches.sh
+++ b/.github/scripts/install_branches.sh
@@ -42,7 +42,9 @@ if [ "${install_from_pypi:-false}" == "true" ]; then
 
   echo "::group::Installing xsuite from PyPI"
   pip uninstall -y xsuite "${repos[@]}"
-  pip install --upgrade xsuite xmask xwakes
+  # We pin ruamel-yaml as it's pinned in conda at the time of writing: otherwise
+  # `pip check` fails, as xcoll by itself will pull a version that's too new
+  pip install --upgrade "xsuite" "xmask" "xwakes" "ruamel-yaml<0.19"
   pip check
   echo "::endgroup::"
 

--- a/xsuite/kernel_definitions.py
+++ b/xsuite/kernel_definitions.py
@@ -46,7 +46,7 @@ kernel_definitions = [
         'config': {**BASE_CONFIG, 'XTRACK_TPSA_TRACK': True},
         'classes': TPSA_SUPPORTED_ELEMENTS,
         'extra_classes': [],
-        'include_monitors': False,
+        'include_monitors': True,
     }),
     ('all_with_synrad', {
         'config': {**BASE_CONFIG, 'XTRACK_MULTIPOLE_NO_SYNRAD': False},

--- a/xsuite/kernel_definitions.py
+++ b/xsuite/kernel_definitions.py
@@ -45,7 +45,7 @@ kernel_definitions = [
     ('tpsa_base_config', {
         'config': {**BASE_CONFIG, 'XTRACK_TPSA_TRACK': True},
         'classes': TPSA_SUPPORTED_ELEMENTS,
-        'extra_classes': [],
+        'extra_classes': [xt.MultiSetter],
         'include_monitors': True,
     }),
     ('all_with_synrad', {

--- a/xsuite/kernel_definitions.py
+++ b/xsuite/kernel_definitions.py
@@ -5,7 +5,8 @@
 import logging
 
 from xtrack.prebuilt_kernel_definitions import (ONLY_XTRACK_ELEMENTS,
-                                    NO_SYNRAD_ELEMENTS, NON_TRACKING_ELEMENTS)
+                                    NO_SYNRAD_ELEMENTS, NON_TRACKING_ELEMENTS,
+                                    TPSA_SUPPORTED_ELEMENTS)
 from xcoll.prebuilt_kernel_definitions import DEFAULT_XCOLL_ELEMENTS, EXTRA_XCOLL_ELEMENTS
 from xfields.prebuilt_kernel_definitions import DEFAULT_XFIELDS_ELEMENTS
 from xfields.prebuilt_kernel_definitions import NON_TRACKING_ELEMENTS as XFIELDS_NON_TRACKING_ELEMENTS
@@ -40,6 +41,12 @@ kernel_definitions = [
         'config': BASE_CONFIG,
         'classes': XTRACK_ELEMENTS + DEFAULT_XFIELDS_ELEMENTS + DEFAULT_XCOLL_ELEMENTS,
         'extra_classes': [xt.Particles] + EXTRA_XCOLL_ELEMENTS,
+    }),
+    ('tpsa_base_config', {
+        'config': {**BASE_CONFIG, 'XTRACK_TPSA_TRACK': True},
+        'classes': TPSA_SUPPORTED_ELEMENTS,
+        'extra_classes': [],
+        'include_monitors': False,
     }),
     ('all_with_synrad', {
         'config': {**BASE_CONFIG, 'XTRACK_MULTIPOLE_NO_SYNRAD': False},

--- a/xsuite/kernel_definitions.py
+++ b/xsuite/kernel_definitions.py
@@ -32,7 +32,9 @@ TPSA_MONITOR_CLASSES = [xt.MultiElementMonitor]
 kernel_definitions = [
     ('non_tracking_kernels', {
         'config': {},
-        'classes': [],
+        # Tracker compilation needs a non-empty ElementRef union even though this
+        # kernel only provides auxiliary kernels.
+        'classes': [xt.Marker],
         'extra_classes': (
             [xt.Particles] + NON_TRACKING_ELEMENTS + XFIELDS_NON_TRACKING_ELEMENTS
             + SCALAR_MONITOR_CLASSES

--- a/xsuite/kernel_definitions.py
+++ b/xsuite/kernel_definitions.py
@@ -25,39 +25,44 @@ BASE_CONFIG = {
     'XTRACK_GLOBAL_XY_LIMIT': 1.0,
 }
 
+SCALAR_MONITOR_CLASSES = [xt.ParticlesMonitor, xt.MultiElementMonitor]
+TPSA_MONITOR_CLASSES = [xt.MultiElementMonitor]
+
 # These are enumerated in order specified below: the highest priority at the top
 kernel_definitions = [
     ('non_tracking_kernels', {
         'config': {},
         'classes': [],
-        'extra_classes': [xt.Particles] + NON_TRACKING_ELEMENTS + XFIELDS_NON_TRACKING_ELEMENTS,
+        'extra_classes': (
+            [xt.Particles] + NON_TRACKING_ELEMENTS + XFIELDS_NON_TRACKING_ELEMENTS
+            + SCALAR_MONITOR_CLASSES
+        ),
     }),
     ('default_no_config', {
         'config': {},
         'classes': XTRACK_ELEMENTS + DEFAULT_XFIELDS_ELEMENTS + DEFAULT_XCOLL_ELEMENTS,
-        'extra_classes': [xt.Particles] + EXTRA_XCOLL_ELEMENTS,
+        'extra_classes': [xt.Particles] + EXTRA_XCOLL_ELEMENTS + SCALAR_MONITOR_CLASSES,
     }),
     ('default_base_config', {
         'config': BASE_CONFIG,
         'classes': XTRACK_ELEMENTS + DEFAULT_XFIELDS_ELEMENTS + DEFAULT_XCOLL_ELEMENTS,
-        'extra_classes': [xt.Particles] + EXTRA_XCOLL_ELEMENTS,
+        'extra_classes': [xt.Particles] + EXTRA_XCOLL_ELEMENTS + SCALAR_MONITOR_CLASSES,
     }),
     ('tpsa_base_config', {
         'config': {**BASE_CONFIG, 'XTRACK_TPSA_TRACK': True},
         'classes': TPSA_SUPPORTED_ELEMENTS,
-        'extra_classes': [xt.MultiSetter],
-        'include_monitors': True,
+        'extra_classes': [xt.MultiSetter] + TPSA_MONITOR_CLASSES,
     }),
     ('all_with_synrad', {
         'config': {**BASE_CONFIG, 'XTRACK_MULTIPOLE_NO_SYNRAD': False},
         'classes': ONLY_XTRACK_ELEMENTS + DEFAULT_XFIELDS_ELEMENTS + DEFAULT_XCOLL_ELEMENTS,
-        'extra_classes': [xt.Particles],
+        'extra_classes': [xt.Particles] + SCALAR_MONITOR_CLASSES,
     }),
     ('all_with_radiative', {
         'config': {**BASE_CONFIG, 'XTRACK_MULTIPOLE_NO_SYNRAD': False,
                    'XFIELDS_BB3D_NO_BEAMSTR': False, 'XFIELDS_BB3D_NO_BHABHA': False},
         'classes': XTRACK_ELEMENTS + DEFAULT_XFIELDS_ELEMENTS + DEFAULT_XCOLL_ELEMENTS,
-        'extra_classes': [xt.Particles],
+        'extra_classes': [xt.Particles] + SCALAR_MONITOR_CLASSES,
     }),
 ]
 

--- a/xsuite/prebuild_kernels.py
+++ b/xsuite/prebuild_kernels.py
@@ -299,6 +299,7 @@ def build_single_kernel(
     config = metadata['config']
     tracker_element_classes = metadata['classes']
     extra_classes = metadata.get('extra_classes', [])
+    include_monitors = metadata.get('include_monitors', True)
     build_context = xo.ContextCpu() if context_key == SERIAL_CONTEXT else xo.ContextCpu(
         omp_num_threads='auto'
     )
@@ -313,11 +314,10 @@ def build_single_kernel(
         kernel_info = xt.Tracker._compile_kernel_from_classes(
             context=build_context,
             config=tracker_config,
-            tracker_element_classes=[
-                *tracker_element_classes,
-                xt.ParticlesMonitor,
-                xt.MultiElementMonitor,
-            ],
+            tracker_element_classes=(
+                [*tracker_element_classes, xt.ParticlesMonitor, xt.MultiElementMonitor]
+                if include_monitors else tracker_element_classes
+            ),
             extra_classes=extra_classes,
             module_name=module_name,
             containing_dir=location,

--- a/xsuite/prebuild_kernels.py
+++ b/xsuite/prebuild_kernels.py
@@ -299,7 +299,6 @@ def build_single_kernel(
     config = metadata['config']
     tracker_element_classes = metadata['classes']
     extra_classes = metadata.get('extra_classes', [])
-    include_monitors = metadata.get('include_monitors', True)
     build_context = xo.ContextCpu() if context_key == SERIAL_CONTEXT else xo.ContextCpu(
         omp_num_threads='auto'
     )
@@ -314,10 +313,7 @@ def build_single_kernel(
         kernel_info = xt.Tracker._compile_kernel_from_classes(
             context=build_context,
             config=tracker_config,
-            tracker_element_classes=(
-                [*tracker_element_classes, xt.ParticlesMonitor, xt.MultiElementMonitor]
-                if include_monitors else tracker_element_classes
-            ),
+            tracker_element_classes=tracker_element_classes,
             extra_classes=extra_classes,
             module_name=module_name,
             containing_dir=location,


### PR DESCRIPTION
## Description

- Add a prebuilt kernel for TPSA tracking, including a multisetter (limited to `_tpsa_enabled` field reading)
- Monitor definition cleanup
- Add docs for TPSA tracking, marked as experimental

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
