### PR TITLE
Fix: Pin ruamel-yaml<0.19 in PyPI installation to match conda constraint

### DIFF
--- a/.github/scripts/install_branches.sh
+++ b/.github/scripts/install_branches.sh
@@ -42,7 +42,9 @@ if [ "${install_from_pypi:-false}" == "true" ]; then
 
   echo "::group::Installing xsuite from PyPI"
   pip uninstall -y xsuite "${repos[@]}"
-  pip install --upgrade xsuite xmask xwakes
+  # We pin ruamel-yaml as it's pinned in conda at the time of writing: otherwise
+  # `pip check` fails, as xcoll by itself will pull a version that's too new
+  pip install --upgrade "xsuite" "xmask" "xwakes" "ruamel-yaml<0.19"
   pip check
   echo "::endgroup::"
 


### PR DESCRIPTION
## Description

When installing from PyPI with Python 3.13, conda's pinning requires `ruamel-yaml<0.19` due to breaking changes in 0.19.0. However, `pip install` without this constraint pulls the latest version (0.19.1), causing a dependency conflict during `pip check`.

This fix explicitly pins `ruamel-yaml<0.19` when installing xsuite packages from PyPI, ensuring compatibility with conda's environment constraints.

Fixes the "conda 26.7.2 has requirement ruamel-yaml<0.19,>=0.11.14" error in PyPI-based test workflows."
